### PR TITLE
Additional informations to be integrated in timeline

### DIFF
--- a/docs/openapi/schemas-paper-v1.yaml
+++ b/docs/openapi/schemas-paper-v1.yaml
@@ -61,6 +61,7 @@ components:
     SendResponse:
       required:
       - amount
+      - envelopeWeight
       type: object
       properties:
         amount:
@@ -68,6 +69,19 @@ components:
           format: int32
           description: ammontare in eurocent del costo per l'invio della notifica
             in forma cartacea
+        envelopeWeight:
+          type: integer
+          format: int32
+          description: peso in grammi della busta
+        zip:
+          type: string
+          description: Cap del destinatario in caso di invio nazionale; in caso di invio estero diventa facoltativo.
+        foreignState:
+          type: string
+          description:  "In caso di destinatario estero, diventa obbligatoria l’indicazione\
+          \ della nazione di destinazione,  in standard UPU o altro standard condiviso."
+
+
 
     StatusCodeEnum:
       type: string

--- a/docs/openapi/schemas-paper-v1.yaml
+++ b/docs/openapi/schemas-paper-v1.yaml
@@ -62,6 +62,7 @@ components:
       required:
       - amount
       - envelopeWeight
+      - numberOfPages
       type: object
       properties:
         amount:
@@ -69,6 +70,10 @@ components:
           format: int32
           description: ammontare in eurocent del costo per l'invio della notifica
             in forma cartacea
+        numberOfPages:
+          type: integer
+          format: int32
+          description: numero delle pagina che compongono la spedizione cartacea
         envelopeWeight:
           type: integer
           format: int32


### PR DESCRIPTION
Aggiunta l'indicazione sul peso.

Per coerenza sono state aggiunte anche le informazioni riguardanti cap e stato estero (da aggiungere obbligatoriamente in XOR), è questa la risposta che attesta l'effettiva presa in carico della spedizione.
Da capire se invece queste info si vogliono dedurre da step precedenti