### PR TITLE
feature/PN-8911

### DIFF
--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/EventMetaDAO.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/EventMetaDAO.java
@@ -7,6 +7,8 @@ import reactor.core.publisher.Mono;
 public interface EventMetaDAO {
     Mono<PnEventMeta> createOrUpdate(PnEventMeta pnEventMeta);
 
+    Mono<PnEventMeta> putIfAbsent(PnEventMeta pnEventMeta);
+
     Mono<PnEventMeta> getDeliveryEventMeta(String metaRequestId, String metaStatusCode);
 
     Flux<PnEventMeta> findAllByRequestId(String metaRequestId);

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/common/BaseDAO.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/common/BaseDAO.java
@@ -73,6 +73,14 @@ public abstract class BaseDAO<T> {
         });
     }
 
+    protected CompletableFuture<T> put(PutItemEnhancedRequest<T> putItemEnhancedRequest){
+        log.logPuttingDynamoDBEntity(dynamoTable.tableName(), putItemEnhancedRequest.item());
+        return dynamoTable.putItem(putItemEnhancedRequest).thenApply(x -> {
+            log.logPutDoneDynamoDBEntity(dynamoTable.tableName());
+            return putItemEnhancedRequest.item();
+        });
+    }
+
     protected CompletableFuture<T> delete(String partitionKey, String sortKey){
         Key.Builder keyBuilder = Key.builder().partitionValue(partitionKey);
         if (!StringUtils.isBlank(sortKey)){

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/impl/EventMetaDAOImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/impl/EventMetaDAOImpl.java
@@ -4,15 +4,22 @@ import it.pagopa.pn.paperchannel.config.AwsPropertiesConfig;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.dao.common.BaseDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+
+import static it.pagopa.pn.commons.abstractions.impl.AbstractDynamoKeyValueStore.ATTRIBUTE_NOT_EXISTS;
 
 @Repository
+@Slf4j
 public class EventMetaDAOImpl extends BaseDAO<PnEventMeta> implements EventMetaDAO {
     public EventMetaDAOImpl(DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient,
                        DynamoDbAsyncClient dynamoDbAsyncClient,
@@ -24,6 +31,33 @@ public class EventMetaDAOImpl extends BaseDAO<PnEventMeta> implements EventMetaD
     @Override
     public Mono<PnEventMeta> createOrUpdate(PnEventMeta pnEventMeta) {
         return Mono.fromFuture(put(pnEventMeta).thenApply(item -> item));
+    }
+
+    @Override
+    public Mono<PnEventMeta> putIfAbsent(PnEventMeta pnEventMeta) {
+        String expression = String.format(
+                "%s(%s) AND %s(%s)",
+                ATTRIBUTE_NOT_EXISTS,
+                PnEventMeta.COL_PK,
+                ATTRIBUTE_NOT_EXISTS,
+                PnEventMeta.COL_SK
+        );
+
+        Expression conditionExpressionPut = Expression.builder()
+                .expression(expression)
+                .build();
+
+        PutItemEnhancedRequest<PnEventMeta> request = PutItemEnhancedRequest.builder( PnEventMeta.class )
+                .item(pnEventMeta )
+                .conditionExpression( conditionExpressionPut )
+                .build();
+
+        return Mono.fromFuture(put(request)).thenReturn(pnEventMeta)
+                .onErrorResume(ConditionalCheckFailedException.class, e -> {
+                            log.warn("ConditionalCheckFailed for putting entity: {}", pnEventMeta);
+                            return Mono.empty();
+                        }
+                );
     }
 
     @Override

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnEventMeta.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnEventMeta.java
@@ -17,8 +17,8 @@ import java.time.Instant;
 @ToString
 @DynamoDbBean
 public class PnEventMeta {
-    private static final String COL_PK = "pk";
-    private static final String COL_SK = "sk";
+    public static final String COL_PK = "pk";
+    public static final String COL_SK = "sk";
 
     private static final String COL_REQUEST_ID = "requestId";
     private static final String COL_STATUS_CODE = "statusCode";

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
@@ -53,7 +53,8 @@ public class HandlersFactory {
         var directlySendMessageHandler = new DirectlySendMessageHandler(sqsSender);
         var recag012MessageHandler = new RECAG012MessageHandler(eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
         var recag011AMessageHandler =  new RECAG011AMessageHandler(sqsSender, eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
-        var recag011BMessageHandler = new RECAG011BMessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
+        var pnag012MessageHandler = new PNAG012MessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
+        var recag011BMessageHandler = new RECAG011BMessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), pnag012MessageHandler);
         var recag008CMessageHandler = new RECAG008CMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
         var complex890MessageHandler = new Complex890MessageHandler(sqsSender, eventMetaDAO, metaDematCleaner, pnPaperChannelConfig.getRefinementDuration() );
         var recrn00xcMessageHandler = new RECRN00XCMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner, pnPaperChannelConfig.getRefinementDuration());
@@ -85,6 +86,7 @@ public class HandlersFactory {
         map.put("RECRN003C", recrn00xcMessageHandler);
         map.put("RECRN004C", recrn00xcMessageHandler);
         map.put("RECRN005C", recrn00xcMessageHandler);
+        map.put("PNAG012", pnag012MessageHandler);
     }
 
     private void addRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, RetryableErrorMessageHandler handler) {
@@ -134,35 +136,6 @@ public class HandlersFactory {
         map.put("RECRSI004A", handler);
     }
 
-//    private void addDemaSavedStatusCodes(ConcurrentHashMap<DematKey, MessageHandler> map, DematMessageHandler handler) {
-//
-//        map.put(new DematKey("RECAG002B", "CAN"), handler);
-//
-//    }
-
-
-//    private void addDematDeliveryPushStatusCodes(ConcurrentHashMap<DematKey, MessageHandler> map, SaveDematMessageHandler handler) {
-//        map.put(new DematKey("RECRS002B", "Plico"), handler);
-//        map.put(new DematKey("RECRS002E", "Plico"), handler);
-//        map.put(new DematKey("RECRS004B", "Plico"), handler);
-//        map.put(new DematKey("RECRS005B", "Plico"), handler);
-//        map.put(new DematKey("RECRN001B", "AR"), handler);
-//        map.put(new DematKey("RECRN002B", "Plico"), handler);
-//        map.put(new DematKey("RECRN002E", "Plico"), handler);
-//        map.put(new DematKey("RECRN002E", "Indagine"), handler);
-//        map.put(new DematKey("RECRN003B", "AR"), handler);
-//        map.put(new DematKey("RECRN004B", "Plico"), handler);
-//        map.put(new DematKey("RECRN005B", "Plico"), handler);
-//        map.put(new DematKey("RECAG001B", "23L"), handler);
-//        map.put(new DematKey("RECAG002B", "23L"), handler); //CAN è una raccomandata semplice che, se consegnata, non ha materialità da dematerializzare. in caso non fosse recapitata avrà una dematerializzazione del plico di tipo CAN
-//        map.put(new DematKey("RECAG003B", "Plico"), handler);
-//        map.put(new DematKey("RECAG003E", "Plico"), handler);
-//        map.put(new DematKey("RECAG003E", "Indagine"), handler);
-//        map.put(new DematKey("RECRI003B", "AR"), handler);
-//        map.put(new DematKey("RECRI004B", "Plico"), handler);
-//        map.put(new DematKey("RECRSI004B", "Plico"), handler);
-//
-//    }
 
     private void addSaveDematStatusCodes(ConcurrentHashMap<String, MessageHandler> map, SaveDematMessageHandler handler) {
         map.put(ExternalChannelCodeEnum.RECRS002B.name(), handler);

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
@@ -51,9 +51,9 @@ public class HandlersFactory {
         var customAggregatorMessageHandler = new CustomAggregatorMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
         var aggregatorMessageHandler = new AggregatorMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
         var directlySendMessageHandler = new DirectlySendMessageHandler(sqsSender);
-        var recag012MessageHandler = new RECAG012MessageHandler(eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
-        var recag011AMessageHandler =  new RECAG011AMessageHandler(sqsSender, eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
         var pnag012MessageHandler = new PNAG012MessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
+        var recag012MessageHandler = new RECAG012MessageHandler(eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta(), pnag012MessageHandler);
+        var recag011AMessageHandler =  new RECAG011AMessageHandler(sqsSender, eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
         var recag011BMessageHandler = new RECAG011BMessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), pnag012MessageHandler);
         var recag008CMessageHandler = new RECAG008CMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
         var complex890MessageHandler = new Complex890MessageHandler(sqsSender, eventMetaDAO, metaDematCleaner, pnPaperChannelConfig.getRefinementDuration() );

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -93,6 +93,6 @@ public class PNAG012MessageHandler extends SaveDematMessageHandler {
         pnLogAudit.addsBeforeReceive(pnag012DeliveryRequest.getIun(), String.format("prepare requestId = %s Response from external-channel", pnag012DeliveryRequest.getRequestId()));
         return eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)
                 .doOnNext(pnEventMetaRECAG012Updated -> logSuccessAuditLog(pnag012PaperRequest, pnag012DeliveryRequest, pnLogAudit))
-                .thenReturn(pnag012Wrapper);
+                .map(pnEventMeta -> pnag012Wrapper);
     }
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -20,6 +20,10 @@ import java.util.Optional;
 import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.WRONG_EVENT_ORDER;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 
+/**
+ * Questo handler è l'unico in cui viene scatenato da un altro handler, {@link RECAG011BMessageHandler}
+ * e non da direttamente da un evento di ext-channel.
+ */
 @Slf4j
 public class PNAG012MessageHandler extends SaveDematMessageHandler {
 

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -22,6 +22,14 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
  * Questo handler è l'unico in cui viene scatenato da altri handler, {@link RECAG011BMessageHandler} e {@link RECAG012MessageHandler}
  * e non direttamente da un evento di ext-channel.
  */
+// 1. Chiamare una batchGetItems utilizzando le seguenti chiavi:
+//        23L##RECAG011B
+//        ARCAD##RECAG011B
+//        CAD##RECAG011B
+// 2. Nel caso in cui risultano presenti il 23L##RECAG011B e uno degli altri due element effettuare la transizione in "Distacco d'ufficio 23L fascicolo chiuso":
+//        1. Recuperare l’evento con SK META##RECAG012 e recuperare la statusDateTime (se non esiste il record, bloccare il flusso)
+//        2. effettuare PUT_IF_ABSENT di una nuova riga correlata all’evento PNAG012 in tabella impostando come statusDateTime quella recuperata al punto precedente
+//        3. inoltrare l’evento PNAG012 verso delivery_push (solo se la PUT_IF_ABSENT ha inserito il record)
 @Slf4j
 public class PNAG012MessageHandler extends SaveDematMessageHandler {
 

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -93,6 +93,6 @@ public class PNAG012MessageHandler extends SaveDematMessageHandler {
         pnLogAudit.addsBeforeReceive(pnag012DeliveryRequest.getIun(), String.format("prepare requestId = %s Response from external-channel", pnag012DeliveryRequest.getRequestId()));
         return eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)
                 .doOnNext(pnEventMetaRECAG012Updated -> logSuccessAuditLog(pnag012PaperRequest, pnag012DeliveryRequest, pnLogAudit))
-                .map(pnEventMeta -> pnag012Wrapper);
+                .map(pnEventMeta -> pnag012Wrapper); //blocco il flusso se la putIfAbsent non inserisce a DB
     }
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -1,0 +1,91 @@
+package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
+
+import it.pagopa.pn.commons.log.PnAuditLogBuilder;
+import it.pagopa.pn.paperchannel.exception.PnGenericException;
+import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
+import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
+import it.pagopa.pn.paperchannel.middleware.queue.model.PNAG012Wrapper;
+import it.pagopa.pn.paperchannel.service.SqsSender;
+import it.pagopa.pn.paperchannel.utils.PnLogAudit;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.WRONG_EVENT_ORDER;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
+
+@Slf4j
+public class PNAG012MessageHandler extends SaveDematMessageHandler {
+
+    protected static final String META_SORT_KEY_FILTER = buildMetaStatusCode(RECAG012_STATUS_CODE);
+    private static final String DEMAT_23L_RECAG011B = buildDocumentTypeStatusCode("23L", RECAG011B_STATUS_CODE);
+
+    private static final String DEMAT_ARCAD_RECAG011B = buildDocumentTypeStatusCode("ARCAD", RECAG011B_STATUS_CODE);
+
+    private static final String DEMAT_CAD_RECAG011B = buildDocumentTypeStatusCode("CAD", RECAG011B_STATUS_CODE);
+    protected static final String[] DEMAT_SORT_KEYS_FILTER = {
+            DEMAT_23L_RECAG011B,
+            DEMAT_ARCAD_RECAG011B,
+            DEMAT_CAD_RECAG011B,
+    };
+
+    private final EventMetaDAO eventMetaDAO;
+
+    private final Long ttlDaysMeta;
+
+    public PNAG012MessageHandler(SqsSender sqsSender, EventDematDAO eventDematDAO, Long ttlDaysDemat, EventMetaDAO eventMetaDAO, Long ttlDaysMeta) {
+        super(sqsSender, eventDematDAO, ttlDaysDemat);
+        this.eventMetaDAO = eventMetaDAO;
+        this.ttlDaysMeta = ttlDaysMeta;
+    }
+
+    @Override
+    public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {
+        String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
+        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+
+        PnAuditLogBuilder auditLogBuilder = new PnAuditLogBuilder();
+        PnLogAudit pnLogAudit = new PnLogAudit(auditLogBuilder);
+
+        return super.eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER).collectList()
+                .filter(this::canCreatePNAG012Event)
+                .doOnNext(pnEventDemats -> log.info("[{}] CanCreatePNAG012Event Filter success", paperRequest.getRequestId()))
+                .flatMap(pnEventDemats -> eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER)
+                        .switchIfEmpty(Mono.error(new PnGenericException(WRONG_EVENT_ORDER, "[{" + paperRequest.getRequestId() + "}] Missing EventMeta for {" + paperRequest + "}")))
+                )
+                .doOnNext(pnEventMeta -> log.info("[{}] PnEventMeta found: {}", paperRequest.getRequestId(), pnEventMeta))
+                .map(pnEventMetaRECAG012 -> createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, ttlDaysMeta))
+                .flatMap(pnEventMetaPNAG012 -> this.pnag012Flow(pnEventMetaPNAG012, entity, paperRequest, pnLogAudit))
+                .doOnNext(pnag012Wrapper -> log.info("[{}] Sending PNAG012 to delivery push: {}", pnag012Wrapper.getPaperProgressStatusEventDtoPNAG012().getRequestId(), pnag012Wrapper.getPnDeliveryRequestPNAG012()))
+                .flatMap(pnag012Wrapper -> super.sendToDeliveryPush(pnag012Wrapper.getPnDeliveryRequestPNAG012(), pnag012Wrapper.getPaperProgressStatusEventDtoPNAG012()));
+    }
+
+    private boolean canCreatePNAG012Event(List<PnEventDemat> pnEventDemats) {
+        Optional<PnEventDemat> twentyThreeLElement = pnEventDemats.stream()
+                .filter(pnEventDemat -> DEMAT_23L_RECAG011B.equals(pnEventDemat.getDocumentTypeStatusCode()))
+                .findFirst();
+
+        Optional<PnEventDemat> arcadOrCadElement = pnEventDemats.stream()
+                .filter(pnEventDemat -> DEMAT_ARCAD_RECAG011B.equals(pnEventDemat.getDocumentTypeStatusCode()) ||
+                        DEMAT_CAD_RECAG011B.equals(pnEventDemat.getDocumentTypeStatusCode()))
+                .findFirst();
+
+        return twentyThreeLElement.isPresent() && arcadOrCadElement.isPresent();
+    }
+
+    private Mono<PNAG012Wrapper> pnag012Flow(PnEventMeta pnEventMetaPNAG012, PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest, PnLogAudit pnLogAudit) {
+        PNAG012Wrapper pnag012Wrapper = PNAG012Wrapper.buildPNAG012Wrapper(entity, paperRequest, pnEventMetaPNAG012.getStatusDateTime());
+        var pnag012PaperRequest = pnag012Wrapper.getPaperProgressStatusEventDtoPNAG012();
+        var pnag012DeliveryRequest = pnag012Wrapper.getPnDeliveryRequestPNAG012();
+        pnLogAudit.addsBeforeReceive(pnag012DeliveryRequest.getIun(), String.format("prepare requestId = %s Response from external-channel", pnag012DeliveryRequest.getRequestId()));
+        return eventMetaDAO.createOrUpdate(pnEventMetaPNAG012)
+                .doOnNext(pnEventMetaRECAG012Updated -> logSuccessAuditLog(pnag012PaperRequest, pnag012DeliveryRequest, pnLogAudit))
+                .thenReturn(pnag012Wrapper);
+    }
+}

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -20,7 +20,7 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 
 /**
  * Questo handler è l'unico in cui viene scatenato da altri handler, {@link RECAG011BMessageHandler} e {@link RECAG012MessageHandler}
- * e non da direttamente da un evento di ext-channel.
+ * e non direttamente da un evento di ext-channel.
  */
 @Slf4j
 public class PNAG012MessageHandler extends SaveDematMessageHandler {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -91,7 +91,7 @@ public class PNAG012MessageHandler extends SaveDematMessageHandler {
         var pnag012PaperRequest = pnag012Wrapper.getPaperProgressStatusEventDtoPNAG012();
         var pnag012DeliveryRequest = pnag012Wrapper.getPnDeliveryRequestPNAG012();
         pnLogAudit.addsBeforeReceive(pnag012DeliveryRequest.getIun(), String.format("prepare requestId = %s Response from external-channel", pnag012DeliveryRequest.getRequestId()));
-        return eventMetaDAO.createOrUpdate(pnEventMetaPNAG012)
+        return eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)
                 .doOnNext(pnEventMetaRECAG012Updated -> logSuccessAuditLog(pnag012PaperRequest, pnag012DeliveryRequest, pnLogAudit))
                 .thenReturn(pnag012Wrapper);
     }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandler.java
@@ -1,25 +1,11 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
-import it.pagopa.pn.commons.log.PnAuditLogBuilder;
-import it.pagopa.pn.paperchannel.exception.PnGenericException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
-import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
-import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
-import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
-import it.pagopa.pn.paperchannel.middleware.queue.model.PNAG012Wrapper;
 import it.pagopa.pn.paperchannel.service.SqsSender;
-import it.pagopa.pn.paperchannel.utils.PnLogAudit;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
-
-import java.util.List;
-import java.util.Optional;
-
-import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.WRONG_EVENT_ORDER;
-import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
-import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildDocumentTypeStatusCode;
 
 // 1. effettuare PUT di una riga per ogni documento dematerializzato allegato in accordo con le specifiche
 // 2. invocare contestualmente alla PUT una batchGetItems utilizzando le seguenti chiavi:
@@ -34,75 +20,19 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildDocumentTypeSt
 @Slf4j
 public class RECAG011BMessageHandler extends SaveDematMessageHandler {
 
+    private final PNAG012MessageHandler pnag012MessageHandler;
 
-    protected static final String META_SORT_KEY_FILTER = buildMetaStatusCode(RECAG012_STATUS_CODE);
-
-    private static final String DEMAT_23L_RECAG011B = buildDocumentTypeStatusCode("23L", RECAG011B_STATUS_CODE);
-
-    private static final String DEMAT_ARCAD_RECAG011B = buildDocumentTypeStatusCode("ARCAD", RECAG011B_STATUS_CODE);
-
-    private static final String DEMAT_CAD_RECAG011B = buildDocumentTypeStatusCode("CAD", RECAG011B_STATUS_CODE);
-
-    protected static final String[] DEMAT_SORT_KEYS_FILTER = {
-            DEMAT_23L_RECAG011B,
-            DEMAT_ARCAD_RECAG011B,
-            DEMAT_CAD_RECAG011B,
-    };
-
-    private final EventMetaDAO eventMetaDAO;
-
-    private final Long ttlDaysMeta;
-
-    public RECAG011BMessageHandler(SqsSender sqsSender, EventDematDAO eventDematDAO, Long ttlDaysDemat, EventMetaDAO eventMetaDAO, Long ttlDaysMeta) {
+    public RECAG011BMessageHandler(SqsSender sqsSender, EventDematDAO eventDematDAO, Long ttlDaysDemat, PNAG012MessageHandler pnag012MessageHandler) {
         super(sqsSender, eventDematDAO, ttlDaysDemat);
-        this.eventMetaDAO = eventMetaDAO;
-        this.ttlDaysMeta = ttlDaysMeta;
+        this.pnag012MessageHandler = pnag012MessageHandler;
     }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {
         log.debug("[{}] RECAG011B handler start", paperRequest.getRequestId());
 
-        String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
-        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
-
-        PnAuditLogBuilder auditLogBuilder = new PnAuditLogBuilder();
-        PnLogAudit pnLogAudit = new PnLogAudit(auditLogBuilder);
         return super.handleMessage(entity, paperRequest)
-                .then(super.eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER).collectList())
-                .filter(this::canCreatePNAG012Event)
-                .doOnNext(pnEventDemats -> log.info("[{}] CanCreatePNAG012Event Filter success", paperRequest.getRequestId()))
-                .flatMap(pnEventDemats -> eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER)
-                        .switchIfEmpty(Mono.error(new PnGenericException(WRONG_EVENT_ORDER, "[{" + paperRequest.getRequestId() + "}] Missing EventMeta for {" + paperRequest + "}")))
-                )
-                .doOnNext(pnEventMeta -> log.info("[{}] PnEventMeta found: {}", paperRequest.getRequestId(), pnEventMeta))
-                .map(pnEventMetaRECAG012 -> createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, ttlDaysMeta))
-                .flatMap(pnEventMetaPNAG012 -> this.pnag012Flow(pnEventMetaPNAG012, entity, paperRequest, pnLogAudit))
-                .doOnNext(pnag012Wrapper -> log.info("[{}] Sending PNAG012 to delivery push: {}", pnag012Wrapper.getPaperProgressStatusEventDtoPNAG012().getRequestId(), pnag012Wrapper.getPnDeliveryRequestPNAG012()))
-                .flatMap(pnag012Wrapper -> super.sendToDeliveryPush(pnag012Wrapper.getPnDeliveryRequestPNAG012(), pnag012Wrapper.getPaperProgressStatusEventDtoPNAG012()));
-    }
-
-    private boolean canCreatePNAG012Event(List<PnEventDemat> pnEventDemats) {
-        Optional<PnEventDemat> twentyThreeLElement = pnEventDemats.stream()
-                .filter(pnEventDemat -> DEMAT_23L_RECAG011B.equals(pnEventDemat.getDocumentTypeStatusCode()))
-                .findFirst();
-
-        Optional<PnEventDemat> arcadOrCadElement = pnEventDemats.stream()
-                .filter(pnEventDemat -> DEMAT_ARCAD_RECAG011B.equals(pnEventDemat.getDocumentTypeStatusCode()) ||
-                        DEMAT_CAD_RECAG011B.equals(pnEventDemat.getDocumentTypeStatusCode()))
-                .findFirst();
-
-        return twentyThreeLElement.isPresent() && arcadOrCadElement.isPresent();
-    }
-
-    private Mono<PNAG012Wrapper> pnag012Flow(PnEventMeta pnEventMetaPNAG012, PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest, PnLogAudit pnLogAudit) {
-        PNAG012Wrapper pnag012Wrapper = PNAG012Wrapper.buildPNAG012Wrapper(entity, paperRequest, pnEventMetaPNAG012.getStatusDateTime());
-        var pnag012PaperRequest = pnag012Wrapper.getPaperProgressStatusEventDtoPNAG012();
-        var pnag012DeliveryRequest = pnag012Wrapper.getPnDeliveryRequestPNAG012();
-        pnLogAudit.addsBeforeReceive(pnag012DeliveryRequest.getIun(), String.format("prepare requestId = %s Response from external-channel", pnag012DeliveryRequest.getRequestId()));
-        return eventMetaDAO.createOrUpdate(pnEventMetaPNAG012)
-                .doOnNext(pnEventMetaRECAG012Updated -> logSuccessAuditLog(pnag012PaperRequest, pnag012DeliveryRequest, pnLogAudit))
-                .thenReturn(pnag012Wrapper);
+                .then(pnag012MessageHandler.handleMessage(entity, paperRequest));
     }
 
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandler.java
@@ -8,14 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 // 1. effettuare PUT di una riga per ogni documento dematerializzato allegato in accordo con le specifiche
-// 2. invocare contestualmente alla PUT una batchGetItems utilizzando le seguenti chiavi:
-//        23L##RECAG011B
-//        ARCAD##RECAG011B
-//        CAD##RECAG011B
-// 3. Nel caso in cui risultano presenti il 23L##RECAG011B e uno degli altri due element effettuare la transizione in "Distacco d'ufficio 23L fascicolo chiuso":
-//        1. Recuperare l’evento con SK META##RECAG012 e recuperare la statusDateTime
-//        2. effettuare PUT di una nuova riga correlata all’evento PNAG012 in tabella impostando come statusDateTime quella recuperata al punto precedente
-//        3. inoltrare l’evento PNAG012 verso delivery_push
+// 2. invocare l'handler di PNAG012
 
 @Slf4j
 public class RECAG011BMessageHandler extends SaveDematMessageHandler {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
@@ -16,7 +16,9 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 
 // Il RECAG012 è considerato come entità logica un metadata
 // Viene cercato sulla tabella META se esiste già l'evento, se non esiste in tabella, viene salvato a DB,
-// altrimenti l'evento arrivato viene ignorato
+// altrimenti l'evento arrivato viene ignorato.
+// Poi, esegue il flusso PNAG012, al netto del superamento delle varie condizioni che si trovano nell'handler del PNAG012.
+// L'aggiunta della gestion del PNAG012 è stata fatta a seguito del task PN-8911.
 @Slf4j
 public class RECAG012MessageHandler extends SaveMetadataMessageHandler {
 

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
@@ -48,9 +48,8 @@ public class RECAG012MessageHandler extends SaveMetadataMessageHandler {
      * @param entity
      * @param paperRequest
      * @return Restituisce l'entità PnDeliveryRequest dato in input, se inserisce il record pnEventMeta in DB (e quindi riceve per
-     * la prima volta l'evento RECAG012.
-     * Se l'evento che riceve è già presente in DB, con gli stessi campi valorizzati, restituisce un Mono.empty.
-     * Se l'evento che riceve è già presente in DB con campi valorizzati diversamente, viene lanciata una eccezione.
+     * la prima volta l'evento RECAG012 oppure se l'evento che riceve è già presente in DB, con gli stessi campi valorizzati.
+     * Se invece l'evento che riceve è già presente in DB ma con campi valorizzati diversamente, viene lanciata una eccezione.
      */
     private Mono<PnDeliveryRequest> saveIfNotExistsInDB(Optional<PnEventMeta> optionalPnEventMeta, PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {
         if(optionalPnEventMeta.isPresent()) {
@@ -62,7 +61,7 @@ public class RECAG012MessageHandler extends SaveMetadataMessageHandler {
             if(! pnEventMetaInDB.equals(pnEventMetaNew)) {
                 throw new PnGenericException(WRONG_RECAG012_DATA, "[{" + paperRequest.getRequestId() + "}] Entity RECAG012 already present. In DB: {" + pnEventMetaInDB + "}, received: {" + pnEventMetaNew + "}");
             }
-            return Mono.empty();
+            return Mono.just(entity);
         }
         else {
             // se non è già presente a DB, lo salvo come entità META

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
@@ -1,0 +1,187 @@
+package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
+
+import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.DiscoveredAddressDto;
+import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
+import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
+import it.pagopa.pn.paperchannel.mapper.common.BaseMapperImpl;
+import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnDiscoveredAddress;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
+import it.pagopa.pn.paperchannel.service.SqsSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.OffsetDateTime;
+
+import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.*;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+class PNAG012MessageHandlerTest {
+
+    private EventDematDAO eventDematDAO;
+
+    private EventMetaDAO eventMetaDAO;
+
+    private SqsSender mockSqsSender;
+
+    private PNAG012MessageHandler handler;
+
+    @BeforeEach
+    public void init() {
+        long ttlDays = 365;
+        eventDematDAO = mock(EventDematDAO.class);
+        eventMetaDAO = mock(EventMetaDAO.class);
+        mockSqsSender = mock(SqsSender.class);
+        handler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays);
+    }
+
+    @Test
+    void okTest() {
+        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
+        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
+                .requestId("requestId")
+                .statusCode("RECAG012")
+                .statusDateTime(instant)
+                .clientRequestTimeStamp(instant)
+                .deliveryFailureCause("M02");
+
+        PnDeliveryRequest entity = new PnDeliveryRequest();
+        entity.setRequestId("requestId");
+        entity.setStatusCode("statusDetail");
+        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+
+        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+        PnEventDemat demat1 = new PnEventDemat();
+        demat1.setDematRequestId(dematRequestId);
+        demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+
+        PnEventDemat demat2 = new PnEventDemat();
+        demat2.setDematRequestId(dematRequestId);
+        demat2.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
+        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
+                .thenReturn(Flux.just(demat1, demat2));
+
+
+        String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
+        PnEventMeta pnEventMetaRECAG012 = buildPnEventMeta(paperRequest);
+        when(eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER))
+                .thenReturn(Mono.just(pnEventMetaRECAG012));
+
+        PnEventMeta pnEventMetaPNAG012 = createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, 365L);
+        when(eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)).thenReturn(Mono.just(pnEventMetaPNAG012));
+
+        // eseguo l'handler
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
+        verify(mockSqsSender, times(1)).pushSendEvent(any());
+
+    }
+
+    @Test
+    void blockedFlowBecauseRECAG012DoesNotExistTest() {
+        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
+        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
+                .requestId("requestId")
+                .statusCode("RECAG012")
+                .statusDateTime(instant)
+                .clientRequestTimeStamp(instant)
+                .deliveryFailureCause("M02");
+
+        PnDeliveryRequest entity = new PnDeliveryRequest();
+        entity.setRequestId("requestId");
+        entity.setStatusCode("statusDetail");
+        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+
+        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+        PnEventDemat demat1 = new PnEventDemat();
+        demat1.setDematRequestId(dematRequestId);
+        demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+
+        PnEventDemat demat2 = new PnEventDemat();
+        demat2.setDematRequestId(dematRequestId);
+        demat2.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
+        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
+                .thenReturn(Flux.just(demat1, demat2));
+
+
+        String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
+        when(eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER))
+                .thenReturn(Mono.empty());
+
+        // eseguo l'handler
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
+
+        //mi aspetto che il flusso venga bloccato e quindi on invii l'evento a delivery-push
+        verify(mockSqsSender, never()).pushSendEvent(any());
+
+    }
+
+    @Test
+    void blockedFlowBecausePNAG012AlreadyInsertedTest() {
+        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
+        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
+                .requestId("requestId")
+                .statusCode("RECAG012")
+                .statusDateTime(instant)
+                .clientRequestTimeStamp(instant)
+                .deliveryFailureCause("M02");
+
+        PnDeliveryRequest entity = new PnDeliveryRequest();
+        entity.setRequestId("requestId");
+        entity.setStatusCode("statusDetail");
+        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+
+        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+        PnEventDemat demat1 = new PnEventDemat();
+        demat1.setDematRequestId(dematRequestId);
+        demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+
+        PnEventDemat demat2 = new PnEventDemat();
+        demat2.setDematRequestId(dematRequestId);
+        demat2.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
+        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
+                .thenReturn(Flux.just(demat1, demat2));
+
+
+        String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
+        PnEventMeta pnEventMetaRECAG012 = buildPnEventMeta(paperRequest);
+        when(eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER))
+                .thenReturn(Mono.just(pnEventMetaRECAG012));
+
+        PnEventMeta pnEventMetaPNAG012 = createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, 365L);
+        when(eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)).thenReturn(Mono.empty());
+
+        // eseguo l'handler
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
+        verify(mockSqsSender, never()).pushSendEvent(any());
+
+    }
+
+    private PnEventMeta buildPnEventMeta(PaperProgressStatusEventDto paperRequest) {
+        PnEventMeta pnEventMeta = new PnEventMeta();
+        pnEventMeta.setMetaRequestId(buildMetaRequestId(paperRequest.getRequestId()));
+        pnEventMeta.setMetaStatusCode(buildMetaStatusCode(paperRequest.getStatusCode()));
+        pnEventMeta.setTtl(paperRequest.getStatusDateTime().plusDays(365).toEpochSecond());
+
+        pnEventMeta.setRequestId(paperRequest.getRequestId());
+        pnEventMeta.setStatusCode(paperRequest.getStatusCode());
+        pnEventMeta.setDeliveryFailureCause(paperRequest.getDeliveryFailureCause());
+
+        if (paperRequest.getDiscoveredAddress() != null)
+        {
+            PnDiscoveredAddress discoveredAddress = new BaseMapperImpl<>(DiscoveredAddressDto.class, PnDiscoveredAddress.class).toDTO(paperRequest.getDiscoveredAddress());
+            pnEventMeta.setDiscoveredAddress(discoveredAddress);
+        }
+
+        pnEventMeta.setStatusDateTime(paperRequest.getStatusDateTime().toInstant());
+        return pnEventMeta;
+    }
+
+
+}

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
@@ -93,7 +93,7 @@ class RECAG011BMessageHandlerTest {
         when(eventMetaDAO.getDeliveryEventMeta("META##requestId", META_SORT_KEY_FILTER))
                 .thenReturn(Mono.just(eventMetaRECAG012Expected));
 
-        when(eventMetaDAO.createOrUpdate(pnEventMeta)).thenReturn(Mono.just(pnEventMeta));
+        when(eventMetaDAO.putIfAbsent(pnEventMeta)).thenReturn(Mono.just(pnEventMeta));
 
         // eseguo l'handler
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
@@ -102,7 +102,7 @@ class RECAG011BMessageHandlerTest {
 
         verify(eventDematDAO, times(1)).findAllByKeys("DEMAT##requestId", DEMAT_SORT_KEYS_FILTER);
         verify(eventMetaDAO, times(1)).getDeliveryEventMeta("META##requestId", META_SORT_KEY_FILTER);
-        verify(eventMetaDAO, times(1)).createOrUpdate(pnEventMeta);
+        verify(eventMetaDAO, times(1)).putIfAbsent(pnEventMeta);
 
         PNAG012Wrapper pnag012Wrapper = PNAG012Wrapper.buildPNAG012Wrapper(entity, paperRequest, eventMetaRECAG012Expected.getStatusDateTime());
         PnDeliveryRequest pnDeliveryRequestPNAG012 = pnag012Wrapper.getPnDeliveryRequestPNAG012();

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
@@ -1,6 +1,5 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
-import it.pagopa.pn.paperchannel.exception.PnGenericException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.AttachmentDetailsDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -180,7 +178,7 @@ class RECAG011BMessageHandlerTest {
     }
 
     @Test
-    void handleMessageKOBecauseZeroResultGetDeliveryEventMetaTest() {
+    void handleMessagePNAGO12BlockBecauseZeroResultGetDeliveryEventMetaTest() {
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -220,9 +218,12 @@ class RECAG011BMessageHandlerTest {
                 .thenReturn(Mono.empty()); // 0 risultati
 
         // eseguo l'handler
-        StepVerifier.create(handler.handleMessage(entity, paperRequest))
-                .expectError(PnGenericException.class)
-                .verify();
+//        StepVerifier.create(handler.handleMessage(entity, paperRequest))
+//                .expectError(PnGenericException.class)
+//                .verify();
+
+        // eseguo l'handler
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 
         testNormalDematFlow(pnEventDematExpected, eventDematToDeliveryPushExpected);
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
@@ -24,13 +24,14 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.RECAG011BMessageHandler.DEMAT_SORT_KEYS_FILTER;
-import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.RECAG011BMessageHandler.META_SORT_KEY_FILTER;
+import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.DEMAT_SORT_KEYS_FILTER;
+import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.META_SORT_KEY_FILTER;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.createMETAForPNAG012Event;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.*;
 
+// Questa classe di test, testa sia l'handler RECAG011BMessageHandler che PNAG012MessageHandler
 class RECAG011BMessageHandlerTest {
 
     private EventDematDAO eventDematDAO;
@@ -41,6 +42,8 @@ class RECAG011BMessageHandlerTest {
 
     private RECAG011BMessageHandler handler;
 
+    private PNAG012MessageHandler pnag012MessageHandler;
+
     @BeforeEach
     public void init() {
         long ttlDays = 365;
@@ -48,7 +51,8 @@ class RECAG011BMessageHandlerTest {
         eventMetaDAO = mock(EventMetaDAO.class);
         mockSqsSender = mock(SqsSender.class);
 
-        handler = new RECAG011BMessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays);
+        pnag012MessageHandler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays);
+        handler = new RECAG011BMessageHandler(mockSqsSender, eventDematDAO, ttlDays, pnag012MessageHandler);
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
@@ -57,6 +57,9 @@ class RECAG012MessageHandlerTest {
         //mi aspetto che salvi l'evento
         verify(mockDao, times(1)).createOrUpdate(pnEventMeta);
 
+        //mi aspetto che faccia il flusso PNAG012
+        verify(mockPnag012MessageHandler, times(1)).handleMessage(entity, paperRequest);
+
     }
 
     @Test
@@ -80,8 +83,10 @@ class RECAG012MessageHandlerTest {
         when(mockPnag012MessageHandler.handleMessage(entity, paperRequest)).thenReturn(Mono.empty());
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 
-        //mi aspetto che salvi l'evento
-        verify(mockDao, times(0)).createOrUpdate(pnEventMeta);
+        //mi aspetto che non salvi l'evento
+        verify(mockDao, never()).createOrUpdate(pnEventMeta);
+        //mi aspetto che faccia lo stesso il flusso PNAG012
+        verify(mockPnag012MessageHandler, times(1)).handleMessage(entity, paperRequest);
 
     }
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
@@ -18,14 +18,17 @@ class RECAG012MessageHandlerTest {
 
     private EventMetaDAO mockDao;
 
+    private PNAG012MessageHandler mockPnag012MessageHandler;
+
     private SaveMetadataMessageHandler handler;
 
 
     @BeforeEach
     public void init() {
         mockDao = mock(EventMetaDAO.class);
+        mockPnag012MessageHandler = mock(PNAG012MessageHandler.class);
         long ttlDays = 365;
-        handler = new RECAG012MessageHandler(mockDao, ttlDays);
+        handler = new RECAG012MessageHandler(mockDao, ttlDays, mockPnag012MessageHandler);
     }
 
     @Test
@@ -47,6 +50,7 @@ class RECAG012MessageHandlerTest {
 
         when(mockDao.getDeliveryEventMeta("META##requestId", "META##RECAG012")).thenReturn(Mono.empty());
         when(mockDao.createOrUpdate(pnEventMeta)).thenReturn(Mono.just(pnEventMeta));
+        when(mockPnag012MessageHandler.handleMessage(entity, paperRequest)).thenReturn(Mono.empty());
 
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
@@ -77,6 +77,7 @@ class RECAG012MessageHandlerTest {
         PnEventMeta pnEventMeta = handler.buildPnEventMeta(paperRequest);
 
         when(mockDao.getDeliveryEventMeta("META##requestId", "META##RECAG012")).thenReturn(Mono.just(pnEventMeta));
+        when(mockPnag012MessageHandler.handleMessage(entity, paperRequest)).thenReturn(Mono.empty());
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 
         //mi aspetto che salvi l'evento


### PR DESCRIPTION
Questa PR comprende la PR https://github.com/pagopa/pn-paper-channel/pull/396 e modifica la logica del **PNAG012**, in particolare:

1. se non trova l’evento **RECAG012**, non va in errore ma logga un warning e blocca il flusso
2. il flusso **PNAG012** non fa più una _createOrUpdate_ in DB, ma una _putIfAbsent_. Se quest’ultima non inserisce a DB perché già esiste il record **PNAG012**, allora non manda l’evento a Delivery Push
3. Inoltre il flusso **RECAG012** esegue il flusso **PNAG012** (al netto del superamento dei filtri etc)