### PR TITLE
bug/PN-9526

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-f24/88e340a3d801c0058a441338ad0e0e6acbec234d/docs/openapi/api-internal-f24.yaml</inputSpec>
+                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-f24/cd33f5d132f6dd2a51bb2cc288c68f11c346edf2/docs/openapi/api-internal-f24.yaml</inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
                             <generateApiDocumentation>false</generateApiDocumentation>

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/msclient/F24Client.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/msclient/F24Client.java
@@ -1,9 +1,11 @@
 package it.pagopa.pn.paperchannel.middleware.msclient;
 
+import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.NumberOfPagesResponseDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.RequestAcceptedDto;
 import reactor.core.publisher.Mono;
 
 public interface F24Client {
 
     Mono<RequestAcceptedDto> preparePDF(String requestId, String setId, String recipientIndex, Integer cost);
+    Mono<NumberOfPagesResponseDto> getNumberOfPages(String setId, String recipientIndex);
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/msclient/impl/F24ClientImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/msclient/impl/F24ClientImpl.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.paperchannel.middleware.msclient.impl;
 
 import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.api.F24ControllerApi;
+import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.NumberOfPagesResponseDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.PrepareF24RequestDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.RequestAcceptedDto;
 import it.pagopa.pn.paperchannel.middleware.msclient.F24Client;
@@ -15,7 +16,10 @@ import java.util.List;
 @Component
 @CustomLog
 public class F24ClientImpl implements F24Client {
+
+    private static final String F24_EXTERNAL_SERVICE = "pn-f24";
     private static final String F_24_GENERATEPDF_DESCRIPTION = "Preparing F24 attachments";
+    private static final String F_24_GET_NUMBER_PAGES_DESCRIPTION = "Retrieve pages number of F24 attachments";
     private final PnPaperChannelConfig pnPaperChannelConfig;
 
     private final F24ControllerApi apiService;
@@ -30,7 +34,7 @@ public class F24ClientImpl implements F24Client {
 
     @Override
     public Mono<RequestAcceptedDto> preparePDF(String requestId, String setId, String recipientIndex, Integer cost) {
-        log.logInvokingAsyncExternalService("pn-f24", F_24_GENERATEPDF_DESCRIPTION, requestId);
+        log.logInvokingAsyncExternalService(F24_EXTERNAL_SERVICE, F_24_GENERATEPDF_DESCRIPTION, requestId);
         PrepareF24RequestDto prepareF24RequestDto = new PrepareF24RequestDto();
         prepareF24RequestDto.setRequestId(requestId);
         prepareF24RequestDto.setSetId(setId);
@@ -48,5 +52,12 @@ public class F24ClientImpl implements F24Client {
                     log.error("Error with Preparing F24 attachments  correlationId={}", requestId, ex);
                     return Mono.error(ex);
                 });
+    }
+
+    @Override
+    public Mono<NumberOfPagesResponseDto> getNumberOfPages(String setId, String recipientIndex) {
+        log.logInvokingExternalService(F24_EXTERNAL_SERVICE, F_24_GET_NUMBER_PAGES_DESCRIPTION);
+
+        return this.apiService.getTotalNumberOfPages(setId, List.of(recipientIndex));
     }
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/msclient/impl/F24ClientImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/msclient/impl/F24ClientImpl.java
@@ -58,6 +58,10 @@ public class F24ClientImpl implements F24Client {
     public Mono<NumberOfPagesResponseDto> getNumberOfPages(String setId, String recipientIndex) {
         log.logInvokingExternalService(F24_EXTERNAL_SERVICE, F_24_GET_NUMBER_PAGES_DESCRIPTION);
 
-        return this.apiService.getTotalNumberOfPages(setId, List.of(recipientIndex));
+        return this.apiService.getTotalNumberOfPages(setId, List.of(recipientIndex))
+                .onErrorResume(ex -> {
+                    log.error("Error while getting number of pages from F24 service", ex);
+                    return Mono.error(ex);
+                });
     }
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/QueueListener.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/QueueListener.java
@@ -168,10 +168,10 @@ public class QueueListener {
                         pnLogAudit.addsBeforeDiscard(entity.getIun(), String.format("requestId = %s finish retry f24 error ?", entity.getRequestId()));
 
                         paperRequestErrorDAO.created(
-                                        entity.getRequestId(),
-                                        F24_ERROR.getMessage(),
-                                        EventTypeEnum.F24_ERROR.name())
-                                .subscribe();
+                                entity.getRequestId(),
+                                entity.getMessage(),
+                                EventTypeEnum.F24_ERROR.name()).subscribe();
+
                         pnLogAudit.addsSuccessDiscard(entity.getIun(), String.format("requestId = %s finish retry f24 error", entity.getRequestId()));
                         return null;
                     },

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/Const.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/Const.java
@@ -34,4 +34,6 @@ public class Const {
     public static final String HEADER_CLIENT_ID = "x-pagopa-paperchannel-cx-id";
     public static final String CONTEXT_KEY_CLIENT_ID = "CLIENT_ID";
     public static final String CONTEXT_KEY_PREFIX_CLIENT_ID = "PREFIX_CLIENT_ID";
+
+    public static final String DOCUMENT_TYPE_F24_SET = "PN_F24_SET";
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/msclient/F24ClientTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/msclient/F24ClientTest.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.paperchannel.middleware.msclient;
 import it.pagopa.pn.paperchannel.config.BaseTest;
 import it.pagopa.pn.paperchannel.exception.PnAddressFlowException;
 import it.pagopa.pn.paperchannel.exception.PnF24FlowException;
+import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.NumberOfPagesResponseDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.RequestAcceptedDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,9 @@ import reactor.core.publisher.Mono;
 
 class F24ClientTest extends BaseTest.WithMockServer {
 
+    private static final String REQUEST_ID = "REQUESTID";
+    private static final String SET_ID = "SETID";
+    private static final String RECIPIENT_INDEX = "0";
 
     @Autowired
     private F24Client f24Client;
@@ -19,14 +23,27 @@ class F24ClientTest extends BaseTest.WithMockServer {
 
     @Test
     void testOK(){
-        RequestAcceptedDto responseDto = f24Client.preparePDF("REQUESTID", "SETID", "0", 100).block();
+        RequestAcceptedDto responseDto = f24Client.preparePDF(REQUEST_ID, SET_ID, RECIPIENT_INDEX, 100).block();
         Assertions.assertNotNull(responseDto);
         Assertions.assertNotNull(responseDto.getStatus());
     }
 
     @Test
     void testKO(){
-        Mono<RequestAcceptedDto> mono = f24Client.preparePDF("REQUESTIDCONFLICT", "SETID", "0", 100);
+        Mono<RequestAcceptedDto> mono = f24Client.preparePDF("REQUESTIDCONFLICT", SET_ID, RECIPIENT_INDEX, 100);
         Assertions.assertThrows(WebClientResponseException.class, mono::block);
+    }
+
+    @Test
+    void testGetNumberOfPagesOK() {
+        NumberOfPagesResponseDto numberOfPagesResponseDtoMono = f24Client.getNumberOfPages(SET_ID, RECIPIENT_INDEX).block();
+        Assertions.assertNotNull(numberOfPagesResponseDtoMono);
+        Assertions.assertNotNull(numberOfPagesResponseDtoMono.getNumberOfPages());
+    }
+
+    @Test
+    void testGetNumberOfPagesKO() {
+        Mono<NumberOfPagesResponseDto> numberOfPagesResponseDtoMono = f24Client.getNumberOfPages("BADSETID", RECIPIENT_INDEX);
+        Assertions.assertThrows(WebClientResponseException.class, numberOfPagesResponseDtoMono::block);
     }
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImplTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImplTest.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.paperchannel.service.impl;
 
 import it.pagopa.pn.commons.log.PnAuditLogBuilder;
 import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
+import it.pagopa.pn.paperchannel.exception.PnF24FlowException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.NumberOfPagesResponseDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.RequestAcceptedDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.CostDTO;
@@ -12,7 +13,6 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnAttachmentInfo;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.msclient.F24Client;
 import it.pagopa.pn.paperchannel.model.Address;
-import it.pagopa.pn.paperchannel.model.PrepareAsyncRequest;
 import it.pagopa.pn.paperchannel.model.StatusDeliveryEnum;
 import it.pagopa.pn.paperchannel.service.F24Service;
 import it.pagopa.pn.paperchannel.service.PaperTenderService;
@@ -21,17 +21,19 @@ import it.pagopa.pn.paperchannel.utils.ChargeCalculationModeEnum;
 import it.pagopa.pn.paperchannel.utils.Const;
 import it.pagopa.pn.paperchannel.utils.PaperCalculatorUtils;
 import it.pagopa.pn.paperchannel.utils.Utility;
-import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
-import org.mockito.internal.matchers.Any;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -44,6 +46,9 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest(classes = {PaperCalculatorUtils.class, F24ServiceImpl.class, PnAuditLogBuilder.class})
 class F24ServiceImplTest {
+
+    private final static String IUN = "IUN123";
+    private final static String F24_FILE_KEY = "f24set://IUN123/1";
 
     @Autowired
     private F24Service f24Service;
@@ -63,162 +68,221 @@ class F24ServiceImplTest {
     private F24Client f24Client;
 
     @Test
-    void checkDeliveryRequestAttachmentForF24() {
-        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest("REQUESTID", StatusDeliveryEnum.IN_PROCESSING);
+    @DisplayName("checkDeliveryRequestAttachmentForF24")
+    void checkDeliveryRequestAttachmentForF24WithF24Attachment() {
 
+        // Given
+        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest("REQUESTID", StatusDeliveryEnum.IN_PROCESSING, 0);
+
+        // When
         boolean res = f24Service.checkDeliveryRequestAttachmentForF24(pnDeliveryRequest);
 
+        // Then
         assertTrue(res);
+    }
 
-        pnDeliveryRequest.getAttachments().get(0).setFileKey("safestorage://filekey123");
-        res = f24Service.checkDeliveryRequestAttachmentForF24(pnDeliveryRequest);
+    @Test
+    @DisplayName("checkDeliveryRequestAttachmentForF24")
+    void checkDeliveryRequestAttachmentForF24WithoutF24Attachment() {
+
+        // Given
+        PnDeliveryRequest pnDeliveryRequest = new PnDeliveryRequest();
+        pnDeliveryRequest.setAttachments(new ArrayList<>());
+
+        // When
+        boolean res = f24Service.checkDeliveryRequestAttachmentForF24(pnDeliveryRequest);
+
+        // Then
         assertFalse(res);
     }
 
-    @Test
-    void preparePDF() {
+    @ParameterizedTest
+    @CsvSource({
+            "AAR, 5, 5, 10, 100",
+            "AAR, 12, 12, 56, 100",
+            "COMPLETE, 5, 5, 10, 4400",
+            "COMPLETE, 4, 8, 20, 6400",
+            "COMPLETE, 4, 8, 50, 12500"
+    })
+    @DisplayName("testPreparePDFSuccess")
+    void testPreparePDFSuccess(String calculationMode, Integer paperWeight, Integer letterWeight, Integer numberOfPages, Integer expectedCost) {
 
         // Given
         String requestid = "REQUESTID";
 
-        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING);
+        ChargeCalculationModeEnum chargeCalculationModeEnum = ChargeCalculationModeEnum.valueOf(calculationMode);
+
+        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING, 10);
 
         NumberOfPagesResponseDto numberOfPagesResponseDto = new NumberOfPagesResponseDto();
-        numberOfPagesResponseDto.setNumberOfPages(10);
+        numberOfPagesResponseDto.setNumberOfPages(numberOfPages);
 
         // When
-        Mockito.when(pnPaperChannelConfig.getChargeCalculationMode()).thenReturn(ChargeCalculationModeEnum.AAR);
+        Mockito.when(pnPaperChannelConfig.getChargeCalculationMode()).thenReturn(chargeCalculationModeEnum);
+        Mockito.when(pnPaperChannelConfig.getPaperWeight()).thenReturn(paperWeight);
+        Mockito.when(pnPaperChannelConfig.getLetterWeight()).thenReturn(letterWeight);
+
         Mockito.when(addressDAO.findByRequestId(Mockito.anyString())).thenReturn(Mono.just(getPnAddress(requestid)));
         Mockito.when(requestDeliveryDAO.updateData(Mockito.any())).thenAnswer(i -> Mono.just(i.getArguments()[0]));
 
         Mockito.when(f24Client.getNumberOfPages(Mockito.anyString(), Mockito.anyString())).thenReturn(Mono.just(numberOfPagesResponseDto));
         Mockito.when(f24Client.preparePDF(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt())).thenReturn(Mono.just(new RequestAcceptedDto()));
 
-        //MOCK RETRIEVE NATIONAL COST
-        Mockito.when(paperTenderService.getCostFrom(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Mono.just(getNationalCost()));
+        Mockito.when(paperTenderService.getCostFrom(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Mono.just(getNationalCost()));
 
         PnDeliveryRequest res = f24Service.preparePDF(pnDeliveryRequest).block();
 
         // Then
+        assertNotNull(res);
         assertEquals(F24_WAITING.getCode(), res.getStatusCode());
+        assertEquals(expectedCost, res.getCost());
     }
 
-    @Test
-    void testPreparePDFCompleteMode() {
+    @ParameterizedTest
+    @EnumSource(ChargeCalculationModeEnum.class)
+    @DisplayName("testPreparePDFWithNoCostSuccess")
+    void testPreparePDFWithNoCostSuccess(ChargeCalculationModeEnum calculationMode) {
 
         // Given
         String requestid = "REQUESTID";
-
-        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING);
-
-        NumberOfPagesResponseDto numberOfPagesResponseDto = new NumberOfPagesResponseDto();
-        numberOfPagesResponseDto.setNumberOfPages(10);
-
-        // When
-        Mockito.when(pnPaperChannelConfig.getChargeCalculationMode()).thenReturn(ChargeCalculationModeEnum.COMPLETE);
-        Mockito.when(addressDAO.findByRequestId(Mockito.anyString())).thenReturn(Mono.just(getPnAddress(requestid)));
-        Mockito.when(requestDeliveryDAO.updateData(Mockito.any())).thenAnswer(i -> Mono.just(i.getArguments()[0]));
-
-        Mockito.when(f24Client.getNumberOfPages(Mockito.anyString(), Mockito.anyString())).thenReturn(Mono.just(numberOfPagesResponseDto));
-        Mockito.when(f24Client.preparePDF(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt())).thenReturn(Mono.just(new RequestAcceptedDto()));
-
-        //MOCK RETRIEVE NATIONAL COST
-        Mockito.when(paperTenderService.getCostFrom(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Mono.just(getNationalCost()));
-
-        PnDeliveryRequest res = f24Service.preparePDF(pnDeliveryRequest).block();
-
-        // Then
-        assertEquals(F24_WAITING.getCode(), res.getStatusCode());
-    }
-
-    @Test
-    void preparePDF_nocost() {
-        String requestid = "REQUESTID";
-        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING);
+        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING, null);
         pnDeliveryRequest.getAttachments().get(0).setFileKey("f24set://IUN123/1");
 
         NumberOfPagesResponseDto numberOfPagesResponseDto = new NumberOfPagesResponseDto();
         numberOfPagesResponseDto.setNumberOfPages(10);
 
+        // When
+        Mockito.when(pnPaperChannelConfig.getChargeCalculationMode()).thenReturn(calculationMode);
         Mockito.when(addressDAO.findByRequestId(Mockito.anyString())).thenReturn(Mono.just(getPnAddress(requestid)));
         Mockito.when(requestDeliveryDAO.updateData(Mockito.any())).thenAnswer(i -> Mono.just(i.getArguments()[0]));
 
         Mockito.when(f24Client.getNumberOfPages(Mockito.anyString(), Mockito.anyString())).thenReturn(Mono.just(numberOfPagesResponseDto));
-        Mockito.when(f24Client.preparePDF(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt())).thenReturn(Mono.just(new RequestAcceptedDto()));
+        Mockito.when(f24Client.preparePDF(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(Mono.just(new RequestAcceptedDto()));
+
+        Mockito.when(paperTenderService.getCostFrom(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Mono.just(getNationalCost()));
 
         PnDeliveryRequest res = f24Service.preparePDF(pnDeliveryRequest).block();
 
+        // Then
+        assertNotNull(res);
         assertEquals(F24_WAITING.getCode(), res.getStatusCode());
     }
 
-    @Test
-    void preparePDF_nocost_0() {
+    @ParameterizedTest
+    @EnumSource(ChargeCalculationModeEnum.class)
+    @DisplayName("testPreparePDFWithCostZeroSuccess")
+    void testPreparePDFWithCostZeroSuccess(ChargeCalculationModeEnum calculationMode) {
+
+        // Given
         String requestid = "REQUESTID";
-        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING);
+        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING, 0);
         pnDeliveryRequest.getAttachments().get(0).setFileKey("f24set://IUN123/1?cost=0");
 
-        Mockito.when(addressDAO.findByRequestId(requestid)).thenReturn(Mono.just(getPnAddress(requestid)));
-        Mockito.when(requestDeliveryDAO.updateData(Mockito.any())).thenAnswer(i -> Mono.just(i.getArguments()[0]));
-        Mockito.when(f24Client.preparePDF(requestid, pnDeliveryRequest.getIun(), "1", null)).thenReturn(Mono.just(new RequestAcceptedDto()));
+        NumberOfPagesResponseDto numberOfPagesResponseDto = new NumberOfPagesResponseDto();
+        numberOfPagesResponseDto.setNumberOfPages(10);
 
+        // When
+        Mockito.when(pnPaperChannelConfig.getChargeCalculationMode()).thenReturn(calculationMode);
+        Mockito.when(addressDAO.findByRequestId(Mockito.anyString())).thenReturn(Mono.just(getPnAddress(requestid)));
+        Mockito.when(requestDeliveryDAO.updateData(Mockito.any())).thenAnswer(i -> Mono.just(i.getArguments()[0]));
+
+        Mockito.when(f24Client.getNumberOfPages(Mockito.anyString(), Mockito.anyString())).thenReturn(Mono.just(numberOfPagesResponseDto));
+        Mockito.when(f24Client.preparePDF(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(Mono.just(new RequestAcceptedDto()));
+
+        Mockito.when(paperTenderService.getCostFrom(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Mono.just(getNationalCost()));
 
         PnDeliveryRequest res = f24Service.preparePDF(pnDeliveryRequest).block();
 
+        // Then
+        assertNotNull(res);
         assertEquals(F24_WAITING.getCode(), res.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("testPreparePDFNumberOfPagesApiFail")
+    void testPreparePDFNumberOfPagesApiFail() {
+
+        // Given
+        String requestid = "REQUESTID";
+
+        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, StatusDeliveryEnum.IN_PROCESSING, 10);
+
+        // When
+        Mockito.when(f24Client.getNumberOfPages(Mockito.anyString(), Mockito.anyString())).thenReturn(Mono.error(new RuntimeException()));
+
+        StepVerifier.create(f24Service.preparePDF(pnDeliveryRequest))
+                .expectErrorMatches((ex) -> {
+                    assertInstanceOf(PnF24FlowException.class, ex);
+                    return true;
+                }).verify();
     }
 
 
     @Test
+    @DisplayName("arrangeF24AttachmentsAndReschedulePrepare")
     void arrangeF24AttachmentsAndReschedulePrepare() {
+
+        // Given
         String requestid = "REQUESTID";
         List<String> urls = List.of("safestorage://123456", "safestorage://9876543");
-        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, F24_WAITING);
-        pnDeliveryRequest.getAttachments().get(0).setFileKey("f24set://IUN123/1?cost=0");
-        pnDeliveryRequest.getAttachments().get(0).setDocumentType("PN_F24_SET");
-        PnAttachmentInfo aar = new PnAttachmentInfo();
-        aar.setFileKey("safestorage://77777");
-        pnDeliveryRequest.getAttachments().add(aar);
+        PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestid, F24_WAITING, 0);
 
-        Mockito.when(requestDeliveryDAO.getByRequestId(requestid)).thenReturn(Mono.just(pnDeliveryRequest));
+        // When
+        Mockito.when(requestDeliveryDAO.getByRequestId(Mockito.anyString())).thenReturn(Mono.just(pnDeliveryRequest));
         Mockito.when(requestDeliveryDAO.updateData(Mockito.any())).thenAnswer(i -> Mono.just(i.getArguments()[0]));
 
         PnDeliveryRequest res = f24Service.arrangeF24AttachmentsAndReschedulePrepare(requestid, urls).block();
 
-        assertEquals(F24_WAITING.getCode(), res.getStatusCode());
-        assertEquals(3, res.getAttachments().size());
+        // Then
         Mockito.verify(this.sqsSender).pushToInternalQueue(Mockito.any());
+
+        assertNotNull(res);
+
+        assertEquals(F24_WAITING.getCode(), res.getStatusCode());
+        assertEquals(4, res.getAttachments().size());
+
+        assertTrue(res.getAttachments().stream().map(PnAttachmentInfo::getFileKey).toList().containsAll(urls));
+        assertFalse(res.getAttachments().stream().map(PnAttachmentInfo::getFileKey).toList().contains(F24_FILE_KEY.concat("?cost=0")));
     }
 
-    @NotNull
-    private PrepareAsyncRequest getPrepareAsyncRequest() {
-        PrepareAsyncRequest prepareAsyncRequest = new PrepareAsyncRequest();
-        prepareAsyncRequest.setRequestId("REQUESTID");
-        prepareAsyncRequest.setIun("IUN123");
-        prepareAsyncRequest.setAttemptRetry(1);
-        return prepareAsyncRequest;
-    }
-
-
-    private PnDeliveryRequest getDeliveryRequest(String requestId, StatusDeliveryEnum status){
+    private PnDeliveryRequest getDeliveryRequest(String requestId, StatusDeliveryEnum status, Integer cost){
         PnDeliveryRequest deliveryRequest= new PnDeliveryRequest();
         List<PnAttachmentInfo> attachmentUrls = new ArrayList<>();
-        PnAttachmentInfo pnAttachmentInfo = new PnAttachmentInfo();
-        pnAttachmentInfo.setDate("");
-        pnAttachmentInfo.setUrl("http://localhost:8080");
-        pnAttachmentInfo.setId("");
-        pnAttachmentInfo.setNumberOfPage(null);
-        pnAttachmentInfo.setDocumentType("");
-        pnAttachmentInfo.setFileKey("f24set://IUN123/1?cost=100");
-        attachmentUrls.add(pnAttachmentInfo);
 
+        String f24FileKey = cost == null ? F24_FILE_KEY : String.format("%s?cost=%s", F24_FILE_KEY, cost);
+
+        PnAttachmentInfo f24PnAttachmentInfo = new PnAttachmentInfo();
+        f24PnAttachmentInfo.setDate("");
+        f24PnAttachmentInfo.setUrl("http://localhost:8080");
+        f24PnAttachmentInfo.setId("");
+        f24PnAttachmentInfo.setNumberOfPage(null);
+        f24PnAttachmentInfo.setDocumentType(Const.DOCUMENT_TYPE_F24_SET);
+        f24PnAttachmentInfo.setFileKey(f24FileKey);
+        attachmentUrls.add(f24PnAttachmentInfo);
+
+        PnAttachmentInfo aarPnAttachmentInfo = new PnAttachmentInfo();
+        aarPnAttachmentInfo.setDate("");
+        aarPnAttachmentInfo.setUrl("http://localhost:8080");
+        aarPnAttachmentInfo.setId("");
+        aarPnAttachmentInfo.setNumberOfPage(1);
+        aarPnAttachmentInfo.setDocumentType(Const.PN_AAR);
+        aarPnAttachmentInfo.setFileKey("safestorage://PN_AAR-12345.pdf");
+        attachmentUrls.add(aarPnAttachmentInfo);
+
+        PnAttachmentInfo notificationPnAttachmentInfo = new PnAttachmentInfo();
+        notificationPnAttachmentInfo.setDate("");
+        notificationPnAttachmentInfo.setUrl("http://localhost:8080");
+        notificationPnAttachmentInfo.setId("");
+        notificationPnAttachmentInfo.setNumberOfPage(10);
+        notificationPnAttachmentInfo.setDocumentType("");
+        notificationPnAttachmentInfo.setFileKey("safestorage://PN_NOTIFICATION_ATTACHMENTS-12345.pdf");
+        attachmentUrls.add(notificationPnAttachmentInfo);
 
         deliveryRequest.setAddressHash(getAddress().convertToHash());
         deliveryRequest.setRequestId(requestId);
         deliveryRequest.setFiscalCode("ABCD123AB501");
         deliveryRequest.setReceiverType("PF");
-        deliveryRequest.setIun("IUN123");
+        deliveryRequest.setIun(IUN);
         deliveryRequest.setCorrelationId("");
         deliveryRequest.setStatusCode(status.getCode());
         deliveryRequest.setStatusDetail(status.getDetail());
@@ -269,8 +333,15 @@ class F24ServiceImplTest {
     private CostDTO getNationalCost() {
         CostDTO dto = new CostDTO();
         dto.setPrice(BigDecimal.valueOf(1.00));
+        dto.setPrice50(BigDecimal.valueOf(2.00));
+        dto.setPrice100(BigDecimal.valueOf(3.00));
+        dto.setPrice250(BigDecimal.valueOf(4.00));
+        dto.setPrice350(BigDecimal.valueOf(5.00));
+        dto.setPrice1000(BigDecimal.valueOf(6.00));
+        dto.setPrice2000(BigDecimal.valueOf(7.00));
         dto.setPriceAdditional(BigDecimal.valueOf(2.00));
         return dto;
     }
+
 
 }

--- a/src/test/resources/F24ClientTest-webhook.json
+++ b/src/test/resources/F24ClientTest-webhook.json
@@ -15,31 +15,76 @@
         "status": "OK"
       }
     }
-  },{
-  "httpRequest": {
-    "path": "/f24-private/prepare/REQUESTIDCONFLICT",
-    "method": "POST"
   },
-  "httpResponse": {
-    "statusCode": 409,
-    "headers": {
-      "content-type": [
-        "application/json"
-      ]
+  {
+    "httpRequest": {
+      "path": "/f24-private/prepare/REQUESTIDCONFLICT",
+      "method": "POST"
     },
-    "body": {
-      "status": 409,
-      "title": "Conflict",
-      "detail": "Conflict",
-      "traceId": "123e4567-e89b-12d3-a456-426614174000",
-      "errors": [
-        {
-          "code": "123-4567",
-          "element": null,
-          "detail": "Conflict"
-        }
-      ]
+    "httpResponse": {
+      "statusCode": 409,
+      "headers": {
+        "content-type": [
+          "application/json"
+        ]
+      },
+      "body": {
+        "status": 409,
+        "title": "Conflict",
+        "detail": "Conflict",
+        "traceId": "123e4567-e89b-12d3-a456-426614174000",
+        "errors": [
+          {
+            "code": "123-4567",
+            "element": null,
+            "detail": "Conflict"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "path": "/f24-private/pdf/SETID/number-of-pages",
+      "method": "GET"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "headers": {
+        "content-type": [
+          "application/json"
+        ]
+      },
+      "body": {
+        "numberOfPages": "10"
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "path": "/f24-private/pdf/BADSETID/number-of-pages",
+      "method": "GET"
+    },
+    "httpResponse": {
+      "statusCode": 500,
+      "headers": {
+        "content-type": [
+          "application/json"
+        ]
+      },
+      "body": {
+        "status": 500,
+        "title": "Internal Server Error",
+        "detail": "Unexpected error occurs",
+        "traceId": "123e4567-e89b-12d3-a456-426614174000",
+        "errors": [
+          {
+            "code": "123-4567",
+            "element": null,
+            "detail": "Unexpected error occurs"
+          }
+        ]
+      }
     }
   }
-}
 ]


### PR DESCRIPTION
## Issue Summary
Paper Channel is not able to compare prepare and send requests in case of F24 attachments because of the asynchronous creation of related files.
In this case it is not possible to retrieve the number of pages related to F24 attachments and so it is not possible to calculate cost before files are generated.

## Solution Description
Paper Channel will use a new API `/number-of-page` exposed by pn24 microservice that calculate the total page number for a specific IUN (set id for safestorage).
In this way Paper Channel is able to calculate the entire cost including F24 attachments