### PR TITLE
feat:(pn-9526): add reduce function to calculate F24 attachment pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-f24/cd33f5d132f6dd2a51bb2cc288c68f11c346edf2/docs/openapi/api-internal-f24.yaml</inputSpec>
+                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-f24/340864a174e9e2ae4a6ecef5bac0c114cd7b21ed/docs/openapi/api-internal-f24.yaml</inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
                             <generateApiDocumentation>false</generateApiDocumentation>

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/msclient/F24ClientTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/msclient/F24ClientTest.java
@@ -38,7 +38,6 @@ class F24ClientTest extends BaseTest.WithMockServer {
     void testGetNumberOfPagesOK() {
         NumberOfPagesResponseDto numberOfPagesResponseDtoMono = f24Client.getNumberOfPages(SET_ID, RECIPIENT_INDEX).block();
         Assertions.assertNotNull(numberOfPagesResponseDtoMono);
-        Assertions.assertNotNull(numberOfPagesResponseDtoMono.getNumberOfPages());
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImplTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImplTest.java
@@ -4,6 +4,7 @@ import it.pagopa.pn.commons.log.PnAuditLogBuilder;
 import it.pagopa.pn.paperchannel.config.HttpConnector;
 import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.exception.PnF24FlowException;
+import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.MetadataPagesDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.NumberOfPagesResponseDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnf24.v1.dto.RequestAcceptedDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnsafestorage.v1.dto.FileDownloadInfoDto;
@@ -23,6 +24,7 @@ import it.pagopa.pn.paperchannel.service.PaperTenderService;
 import it.pagopa.pn.paperchannel.service.SqsSender;
 import it.pagopa.pn.paperchannel.utils.*;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.junit.jupiter.api.DisplayName;
@@ -43,6 +45,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import static it.pagopa.pn.paperchannel.model.StatusDeliveryEnum.F24_WAITING;
 import static org.junit.jupiter.api.Assertions.*;
@@ -111,18 +114,17 @@ class F24ServiceImplTest {
 
     @ParameterizedTest
     @CsvSource(value = {
-            "AAR, 5, 5, 10, 10, 100",
-            "AAR, 12, 12, 10, 56, 100",
-            "AAR, 12, 12, 0, 56, 100",
-            "AAR, 12, 12, NULL, 56, 100",
-            "COMPLETE, 5, 5, 10, 10, 4400",
-            "COMPLETE, 4, 8, 10, 20, 6400",
-            "COMPLETE, 4, 8, 10, 50, 12500",
-            "COMPLETE, 4, 8, 0, 50, 12500",
-            "COMPLETE, 4, 8, NULL, 50, 12500"
+            "AAR, 5, 5, 10, 100",
+            "AAR, 12, 12, 10, 100",
+            "AAR, 12, 12, 0, 100",
+            "AAR, 12, 12, NULL, 100",
+            "COMPLETE, 5, 5, 10, 6400",
+            "COMPLETE, 1, 1, 10, 6200",
+            "COMPLETE, 4, 8, 0, 6400",
+            "COMPLETE, 4, 8, NULL, 6400"
     }, nullValues = {"NULL"})
     @DisplayName("testPreparePDFSuccess")
-    void testPreparePDFSuccess(String calculationMode, Integer paperWeight, Integer letterWeight, Integer f24Cost, Integer f24NumberOfPages, Integer expectedCost) throws IOException {
+    void testPreparePDFSuccess(String calculationMode, Integer paperWeight, Integer letterWeight, Integer f24Cost, Integer expectedCost) throws IOException {
 
         // Given
         String requestId = "REQUESTID";
@@ -135,7 +137,7 @@ class F24ServiceImplTest {
         PnDeliveryRequest pnDeliveryRequest = getDeliveryRequest(requestId, StatusDeliveryEnum.IN_PROCESSING, f24Cost);
 
         NumberOfPagesResponseDto numberOfPagesResponseDto = new NumberOfPagesResponseDto();
-        numberOfPagesResponseDto.setNumberOfPages(f24NumberOfPages);
+        numberOfPagesResponseDto.setF24Set(getF24MetadataPages(10));
 
         FileDownloadResponseDto aarFileDownloadResponse = getFileDownloadDTOResponse(Const.PN_AAR);
         FileDownloadResponseDto attachmentFileDownloadResponse = getFileDownloadDTOResponse(ATTACHMENT_DOC_TYPE);
@@ -231,7 +233,9 @@ class F24ServiceImplTest {
 
         String f24FileKey = f24Cost == null ? F24_FILE_KEY : String.format("%s?cost=%s", F24_FILE_KEY, f24Cost);
 
+        /* F24 Set Attachment */
         PnAttachmentInfo f24PnAttachmentInfo = getPnAttachmentInfo(f24FileKey, Const.DOCUMENT_TYPE_F24_SET);
+
         PnAttachmentInfo aarPnAttachmentInfo = getPnAttachmentInfo("safestorage://PN_AAR-12345.pdf", Const.PN_AAR);
         PnAttachmentInfo notificationPnAttachmentInfo = getPnAttachmentInfo("safestorage://PN_NOTIFICATION_ATTACHMENTS-12345.pdf", ATTACHMENT_DOC_TYPE);
 
@@ -260,6 +264,20 @@ class F24ServiceImplTest {
         deliveryRequest.setAttachments(attachmentUrls);
 
         return deliveryRequest;
+    }
+
+    private List<MetadataPagesDto> getF24MetadataPages(Integer count) {
+
+        List<MetadataPagesDto> f24MetadataPagesDtoList = new ArrayList<>();
+        for (int n = 0; n < count; n++) {
+            MetadataPagesDto metadataPagesDto = new MetadataPagesDto();
+            metadataPagesDto.setNumberOfPages(1);
+            metadataPagesDto.setFileKey(RandomStringUtils.randomAscii(10));
+
+            f24MetadataPagesDtoList.add(metadataPagesDto);
+        }
+
+        return f24MetadataPagesDtoList;
     }
 
     private PnAttachmentInfo getPnAttachmentInfo(String fileKey, String documentType) {


### PR DESCRIPTION
Updated F24 API to retrieve number of pages for each F24 document beloging to a specific set id and aggregate the total number of pages