### PR TITLE
Feature/PN-9734

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -83,4 +83,7 @@ aws.bucket.expiration=300000
 # 1970-01-01T00:00:00Z;AAR,2024-01-31T23:00:00Z;COMPLETE
 pn.paper-channel.date-charge-calculation-modes=1970-01-01T00:00:00Z;AAR,2024-01-01T00:00:00Z;COMPLETE
 
+# Variable that defines all the mandatory demats related (for now) only to PNAG012 events
+pn.paper-channel.required-demats=23L,ARCAD
+
 pn.paper-channel.RequestPaIdOverride = 15376371009

--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -33,6 +33,7 @@
     "RefinementDuration": "1m",
     "CloudwatchMetricCron": "0 */5 * * * *",
     "F24ClientReadTimeoutMillis": "30000",
-    "F24ClientRetryMaxAttempts": "0"
+    "F24ClientRetryMaxAttempts": "0",
+    "RequiredDemats": "23L,ARCAD"
   }
 }

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -328,6 +328,11 @@ Parameters:
     Default: '0'
     Description: 'Max retry attempts for F24 client'
 
+  RequiredDemats:
+    Type: String
+    Default: '23L,ARCAD'
+    Description: 'Variable that defines all the mandatory demats related (for now) only to PNAG012 events, using format <DEMAT_1>,<DEMAT_2>,...,<DEMAT_N>'
+
   # OpenApi Bucket params
   MicroserviceBucketName:
     Type: String
@@ -546,6 +551,7 @@ Resources:
         ContainerEnvEntry55: !Sub 'PN_PAPERCHANNEL_QUEUEF24=${F24ToPaperChannelQueueName}'
         ContainerEnvEntry56: !Sub 'PN_PAPERCHANNEL_F24CLIENT_TIMEOUTMILLIS=${F24ClientReadTimeoutMillis}'
         ContainerEnvEntry57: !Sub 'PN_PAPERCHANNEL_F24CLIENT_RETRYMAXATTEMPTS=${F24ClientRetryMaxAttempts}'
+        ContainerEnvEntry58: !Sub 'PN_PAPERCHANNEL_REQUIREDDEMATS=${RequiredDemats}'
         ContainerSecret1: !Sub 'PN_PAPERCHANNEL_ADDRESSMANAGERAPIKEY=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-PaperChannel-Secrets:AddressManagerApiKey:AWSCURRENT:'
         MicroServiceSecretPrefix: pn-PaperChannel-Secrets
         MappedPaths: '/paper-channel-bo/*,/paper-channel-private/*'

--- a/src/main/java/it/pagopa/pn/paperchannel/config/PnPaperChannelConfig.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/config/PnPaperChannelConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Import;
 import javax.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -58,7 +59,7 @@ public class PnPaperChannelConfig {
     private List<String> dateChargeCalculationModes;
     private Duration refinementDuration;
     private String requestPaIdOverride;
-    private List<String> requiredDemats;
+    private Set<String> requiredDemats;
 
     /**
      * Per l'errore PNADDR001: True se il failureDetailCode D01 deve essere mandato a delivery push (specificando anche l'indirizzo),

--- a/src/main/java/it/pagopa/pn/paperchannel/config/PnPaperChannelConfig.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/config/PnPaperChannelConfig.java
@@ -58,6 +58,7 @@ public class PnPaperChannelConfig {
     private List<String> dateChargeCalculationModes;
     private Duration refinementDuration;
     private String requestPaIdOverride;
+    private List<String> requiredDemats;
 
     /**
      * Per l'errore PNADDR001: True se il failureDetailCode D01 deve essere mandato a delivery push (specificando anche l'indirizzo),

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
@@ -51,7 +51,7 @@ public class HandlersFactory {
         var customAggregatorMessageHandler = new CustomAggregatorMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
         var aggregatorMessageHandler = new AggregatorMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
         var directlySendMessageHandler = new DirectlySendMessageHandler(sqsSender);
-        var pnag012MessageHandler = new PNAG012MessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
+        var pnag012MessageHandler = new PNAG012MessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta(), pnPaperChannelConfig.getRequiredDemats());
         var recag012MessageHandler = new RECAG012MessageHandler(eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta(), pnag012MessageHandler);
         var recag011AMessageHandler =  new RECAG011AMessageHandler(sqsSender, eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
         var recag011BMessageHandler = new RECAG011BMessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), pnag012MessageHandler);

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -9,6 +9,7 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 import it.pagopa.pn.paperchannel.middleware.queue.model.PNAG012Wrapper;
 import it.pagopa.pn.paperchannel.service.SqsSender;
+import it.pagopa.pn.paperchannel.utils.DematDocumentTypeEnum;
 import it.pagopa.pn.paperchannel.utils.PnLogAudit;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -87,18 +88,18 @@ public class PNAG012MessageHandler extends SaveDematMessageHandler {
 
     /**
      * This method evaluates whether it is possible to create and send a PNAG012 event
-     * checking if all required demats are included as subset in pnEventDemats.
+     * checking if all required demats are included as subset of pnEventDemats.
      *
      * @param pnEventDemats the demats to check
-     * @return              true if all required demats are include, false otherwise
+     * @return              true if all required demats are included, false otherwise
      * */
     private boolean canCreatePNAG012Event(List<PnEventDemat> pnEventDemats) {
 
-        // TODO: implement ARCAD-CAD equality method in utils
-
+        // Set ensure no duplicates
         Set<String> recag011bDocumentTypes = pnEventDemats.stream()
                 .filter(pnEventDemat -> pnEventDemat.getStatusCode().equals(RECAG011B_STATUS_CODE))
-                .map(PnEventDemat::getDocumentType).collect(Collectors.toSet());
+                .map(pnEventDemat -> DematDocumentTypeEnum.getAliasFromDocumentType(pnEventDemat.getDocumentType()))
+                .collect(Collectors.toSet());
 
         return recag011bDocumentTypes.containsAll(requiredDemats);
     }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -95,9 +95,10 @@ public class PNAG012MessageHandler extends SaveDematMessageHandler {
      * */
     private boolean canCreatePNAG012Event(List<PnEventDemat> pnEventDemats) {
 
-        // Set ensure no duplicates
+        // Set<> ensure no duplicates
         Set<String> recag011bDocumentTypes = pnEventDemats.stream()
                 .filter(pnEventDemat -> pnEventDemat.getStatusCode().equals(RECAG011B_STATUS_CODE))
+                .filter(pnEventDemat -> pnEventDemat.getDocumentType() != null)
                 .map(pnEventDemat -> DematDocumentTypeEnum.getAliasFromDocumentType(pnEventDemat.getDocumentType()))
                 .collect(Collectors.toSet());
 

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -40,7 +40,7 @@ public class PNAG012MessageHandler extends SaveDematMessageHandler {
 
     protected static final String DEMAT_ARCAD_RECAG011B = buildDocumentTypeStatusCode(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType(), RECAG011B_STATUS_CODE);
 
-    private static final String DEMAT_CAD_RECAG011B = buildDocumentTypeStatusCode(DematDocumentTypeEnum.DEMAT_CAD.getDocumentType(), RECAG011B_STATUS_CODE);
+    protected static final String DEMAT_CAD_RECAG011B = buildDocumentTypeStatusCode(DematDocumentTypeEnum.DEMAT_CAD.getDocumentType(), RECAG011B_STATUS_CODE);
     protected static final String[] DEMAT_SORT_KEYS_FILTER = {
             DEMAT_23L_RECAG011B,
             DEMAT_ARCAD_RECAG011B,

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandler.java
@@ -36,11 +36,11 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 public class PNAG012MessageHandler extends SaveDematMessageHandler {
 
     protected static final String META_SORT_KEY_FILTER = buildMetaStatusCode(RECAG012_STATUS_CODE);
-    protected static final String DEMAT_23L_RECAG011B = buildDocumentTypeStatusCode("23L", RECAG011B_STATUS_CODE);
+    protected static final String DEMAT_23L_RECAG011B = buildDocumentTypeStatusCode(DematDocumentTypeEnum.DEMAT_23L.getDocumentType(), RECAG011B_STATUS_CODE);
 
-    protected static final String DEMAT_ARCAD_RECAG011B = buildDocumentTypeStatusCode("ARCAD", RECAG011B_STATUS_CODE);
+    protected static final String DEMAT_ARCAD_RECAG011B = buildDocumentTypeStatusCode(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType(), RECAG011B_STATUS_CODE);
 
-    private static final String DEMAT_CAD_RECAG011B = buildDocumentTypeStatusCode("CAD", RECAG011B_STATUS_CODE);
+    private static final String DEMAT_CAD_RECAG011B = buildDocumentTypeStatusCode(DematDocumentTypeEnum.DEMAT_CAD.getDocumentType(), RECAG011B_STATUS_CODE);
     protected static final String[] DEMAT_SORT_KEYS_FILTER = {
             DEMAT_23L_RECAG011B,
             DEMAT_ARCAD_RECAG011B,

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/Const.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/Const.java
@@ -36,4 +36,13 @@ public class Const {
     public static final String CONTEXT_KEY_PREFIX_CLIENT_ID = "PREFIX_CLIENT_ID";
 
     public static final String DOCUMENT_TYPE_F24_SET = "PN_F24_SET";
+
+    /* Demat document type constants */
+    public static final String DEMAT_AR = "AR";
+    public static final String DEMAT_ARCAD = "ARCAD";
+    public static final String DEMAT_CAD = "CAD";
+    public static final String DEMAT_23L = "23L";
+    public static final String DEMAT_PLICO = "Plico";
+    public static final String DEMAT_INDAGINE = "Indagine";
+
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
@@ -1,15 +1,30 @@
 package it.pagopa.pn.paperchannel.utils;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 
+/**
+ * <p>
+ *     This enum gathers all demat document types in a type safe way providing some additional utilities:
+ *     <ul>
+ *         <li>Gather demat document types in a centralized enumeration</li>
+ *         <li>Provide aliasing translation when need to refer to same or similar object from a business point of view</li>
+ *         <li>Implement utility methods to retrieve correct value from raw string with fallbacks to avoid throwing exceptions</li>
+ *     </ul>
+ * </p>
+ */
 @Getter
+@Slf4j
 public enum DematDocumentTypeEnum {
     DEMAT_AR("AR", "AR"),
     DEMAT_ARCAD("ARCAD", "ARCAD"),
     DEMAT_CAD("CAD", "ARCAD"),
-    DEMAT_23L("23L", "23L");
+    DEMAT_23L("23L", "23L"),
+    DEMAT_PLICO("Plico", "Plico"),
+    DEMAT_INDAGINE("Indagine", "Indagine");
 
     private final String documentType;
     private final String alias;
@@ -28,12 +43,13 @@ public enum DematDocumentTypeEnum {
      * @return              optional {@link DematDocumentTypeEnum}
      * */
     public static Optional<DematDocumentTypeEnum> fromDocumentType(String documentType) {
-        DematDocumentTypeEnum dematDocumentTypeEnum;
+        DematDocumentTypeEnum dematDocumentTypeEnum = null;
 
         try {
-            dematDocumentTypeEnum = DematDocumentTypeEnum.valueOf(DEMAT_PREFIX + documentType);
+            // use StringUtils#upperCase to avoid null pointer exceptions
+            dematDocumentTypeEnum = DematDocumentTypeEnum.valueOf(DEMAT_PREFIX + StringUtils.upperCase(documentType));
         } catch (IllegalArgumentException e) {
-            dematDocumentTypeEnum = null;
+            log.warn("Cannot find DematDocumentTypeEnum with name {}", documentType);
         }
 
         return Optional.ofNullable(dematDocumentTypeEnum);

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
@@ -2,22 +2,23 @@ package it.pagopa.pn.paperchannel.utils;
 
 import lombok.Getter;
 
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 @Getter
 public enum DematDocumentTypeEnum {
-    DEMAT_AR("AR", Set.of("AR")),
-    DEMAT_ARCAD("ARCAD", Set.of("ARCAD", "CAD")),
-    DEMAT_23L("23L", Set.of("23L"));
+    DEMAT_AR("AR", "AR"),
+    DEMAT_ARCAD("ARCAD", "ARCAD"),
+    DEMAT_CAD("CAD", "ARCAD"),
+    DEMAT_23L("23L", "23L");
 
+    private final String documentType;
     private final String alias;
-    private final Set<String> documentTypes;
 
-    DematDocumentTypeEnum(String alias, Set<String> documentTypes) {
+    private final static String DEMAT_PREFIX = "DEMAT_";
+
+    DematDocumentTypeEnum(String documentType, String alias) {
+        this.documentType = documentType;
         this.alias = alias;
-        this.documentTypes = documentTypes;
     }
 
     /**
@@ -27,9 +28,15 @@ public enum DematDocumentTypeEnum {
      * @return              optional {@link DematDocumentTypeEnum}
      * */
     public static Optional<DematDocumentTypeEnum> fromDocumentType(String documentType) {
-        return Arrays.stream(DematDocumentTypeEnum.values())
-                .filter(dematDocumentTypeEnum -> dematDocumentTypeEnum.getDocumentTypes().contains(documentType))
-                .findFirst();
+        DematDocumentTypeEnum dematDocumentTypeEnum;
+
+        try {
+            dematDocumentTypeEnum = DematDocumentTypeEnum.valueOf(DEMAT_PREFIX + documentType);
+        } catch (IllegalArgumentException e) {
+            dematDocumentTypeEnum = null;
+        }
+
+        return Optional.ofNullable(dematDocumentTypeEnum);
     }
 
     /**

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
@@ -14,22 +14,24 @@ import java.util.*;
  *         <li>Provide aliasing translation when need to refer to same or similar object from a business point of view</li>
  *         <li>Implement utility methods to retrieve correct value from raw string with fallbacks to avoid throwing exceptions</li>
  *     </ul>
+ *
+ *     Document type string values come from {@link Const} class to provide better code maintainability
  * </p>
  */
 @Getter
 @Slf4j
 public enum DematDocumentTypeEnum {
-    DEMAT_AR("AR", "AR"),
-    DEMAT_ARCAD("ARCAD", "ARCAD"),
-    DEMAT_CAD("CAD", "ARCAD"),
-    DEMAT_23L("23L", "23L"),
-    DEMAT_PLICO("Plico", "Plico"),
-    DEMAT_INDAGINE("Indagine", "Indagine");
+    DEMAT_AR(Const.DEMAT_AR, Const.DEMAT_AR),
+    DEMAT_ARCAD(Const.DEMAT_ARCAD, Const.DEMAT_ARCAD),
+    DEMAT_CAD(Const.DEMAT_CAD, Const.DEMAT_ARCAD),
+    DEMAT_23L(Const.DEMAT_23L, Const.DEMAT_23L),
+    DEMAT_PLICO(Const.DEMAT_PLICO, Const.DEMAT_PLICO),
+    DEMAT_INDAGINE(Const.DEMAT_INDAGINE, Const.DEMAT_INDAGINE);
 
     private final String documentType;
     private final String alias;
 
-    private final static String DEMAT_PREFIX = "DEMAT_";
+    private static final String DEMAT_PREFIX = "DEMAT_";
 
     DematDocumentTypeEnum(String documentType, String alias) {
         this.documentType = documentType;

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/DematDocumentTypeEnum.java
@@ -1,0 +1,53 @@
+package it.pagopa.pn.paperchannel.utils;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+
+@Getter
+public enum DematDocumentTypeEnum {
+    DEMAT_AR("AR", Set.of("AR")),
+    DEMAT_ARCAD("ARCAD", Set.of("ARCAD", "CAD")),
+    DEMAT_23L("23L", Set.of("23L"));
+
+    private final String alias;
+    private final Set<String> documentTypes;
+
+    DematDocumentTypeEnum(String alias, Set<String> documentTypes) {
+        this.alias = alias;
+        this.documentTypes = documentTypes;
+    }
+
+    /**
+     * <p> This method retrieve an optional {@link DematDocumentTypeEnum} from a document type. </p>
+     *
+     * @param documentType  document type that must be translated
+     * @return              optional {@link DematDocumentTypeEnum}
+     * */
+    public static Optional<DematDocumentTypeEnum> fromDocumentType(String documentType) {
+        return Arrays.stream(DematDocumentTypeEnum.values())
+                .filter(dematDocumentTypeEnum -> dematDocumentTypeEnum.getDocumentTypes().contains(documentType))
+                .findFirst();
+    }
+
+    /**
+     * <p>
+     *     This method retrieve an alias from document type using {@link DematDocumentTypeEnum}.
+     *     In this way it is possible to gather and retrieve common document type names from different sources.
+     * </p>
+     * <p>
+     *    When {@link DematDocumentTypeEnum} is not found, the same document type is returned.
+     *    <i>Example</i>: in certain cases ARCAD and CAD must be interchangeable
+     * </p>
+     *
+     * @param documentType  document type that must be translated
+     * @return              the alias or same parameter document type if not found
+     * */
+    public static String getAliasFromDocumentType(String documentType) {
+        return fromDocumentType(documentType)
+                .map(DematDocumentTypeEnum::getAlias)
+                .orElse(documentType);
+    }
+}

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/TenderDAOTestIT.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/TenderDAOTestIT.java
@@ -100,7 +100,7 @@ class TenderDAOTestIT extends BaseTest {
         Instant startDate = Instant.parse("2024-01-10T00:20:56.630714800Z");
         Instant endDate = Instant.parse("2024-01-28T00:20:56.630714800Z");
         PnTender tender = this.tenderDAO.getConsolidate(startDate, endDate).block();
-        assertNotNull(tender);
+        assertNull(tender);
     }
 
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.DiscoveredAddressDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
+import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.mapper.common.BaseMapperImpl;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
@@ -11,13 +12,16 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnDiscoveredAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 import it.pagopa.pn.paperchannel.service.SqsSender;
+import it.pagopa.pn.paperchannel.utils.DematDocumentTypeEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.Set;
 
 import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.*;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
@@ -41,12 +45,18 @@ class PNAG012MessageHandlerTest {
         eventMetaDAO = mock(EventMetaDAO.class);
         mockSqsSender = mock(SqsSender.class);
 
-        // TODO: added new HashSet, implement test cases
-        handler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays, new HashSet<>());
+        Set<String> requiredDemats = Set.of(
+                DematDocumentTypeEnum.DEMAT_23L.getDocumentType(),
+                DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType()
+        );
+
+        handler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays, requiredDemats);
     }
 
     @Test
     void okTest() {
+
+        // Given
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -61,16 +71,29 @@ class PNAG012MessageHandlerTest {
         entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
 
         String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+
         PnEventDemat demat1 = new PnEventDemat();
         demat1.setDematRequestId(dematRequestId);
         demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+        demat1.setStatusCode(RECAG011B_STATUS_CODE);
+        demat1.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
 
         PnEventDemat demat2 = new PnEventDemat();
         demat2.setDematRequestId(dematRequestId);
         demat2.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
-        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
-                .thenReturn(Flux.just(demat1, demat2));
+        demat2.setStatusCode(RECAG011B_STATUS_CODE);
+        demat2.setDocumentType(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType());
 
+        /* Not known Demat 3 must not interfere with required demats check */
+        PnEventDemat demat3 = new PnEventDemat();
+        demat3.setDematRequestId(dematRequestId);
+        demat3.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
+        demat3.setStatusCode(RECAG011B_STATUS_CODE);
+        demat3.setDocumentType("AnotherDocumentType");
+
+        // When
+        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
+                .thenReturn(Flux.just(demat1, demat2, demat3));
 
         String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
         PnEventMeta pnEventMetaRECAG012 = buildPnEventMeta(paperRequest);
@@ -80,6 +103,7 @@ class PNAG012MessageHandlerTest {
         PnEventMeta pnEventMetaPNAG012 = createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, 365L);
         when(eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)).thenReturn(Mono.just(pnEventMetaPNAG012));
 
+        // Then
         // eseguo l'handler
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
         verify(mockSqsSender, times(1)).pushSendEvent(any());
@@ -88,6 +112,8 @@ class PNAG012MessageHandlerTest {
 
     @Test
     void blockedFlowBecauseRECAG012DoesNotExistTest() {
+
+        // Given
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -102,21 +128,28 @@ class PNAG012MessageHandlerTest {
         entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
 
         String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+
         PnEventDemat demat1 = new PnEventDemat();
         demat1.setDematRequestId(dematRequestId);
         demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+        demat1.setStatusCode(RECAG011B_STATUS_CODE);
+        demat1.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
 
         PnEventDemat demat2 = new PnEventDemat();
         demat2.setDematRequestId(dematRequestId);
         demat2.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
+        demat2.setStatusCode(RECAG011B_STATUS_CODE);
+        demat2.setDocumentType(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType());
+
+        // When
         when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
                 .thenReturn(Flux.just(demat1, demat2));
-
 
         String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
         when(eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER))
                 .thenReturn(Mono.empty());
 
+        // Then
         // eseguo l'handler
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 
@@ -127,6 +160,8 @@ class PNAG012MessageHandlerTest {
 
     @Test
     void blockedFlowBecausePNAG012AlreadyInsertedTest() {
+
+        // Given
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -141,13 +176,20 @@ class PNAG012MessageHandlerTest {
         entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
 
         String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+
         PnEventDemat demat1 = new PnEventDemat();
         demat1.setDematRequestId(dematRequestId);
         demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+        demat1.setStatusCode(RECAG011B_STATUS_CODE);
+        demat1.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
 
         PnEventDemat demat2 = new PnEventDemat();
         demat2.setDematRequestId(dematRequestId);
         demat2.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
+        demat2.setStatusCode(RECAG011B_STATUS_CODE);
+        demat2.setDocumentType(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType());
+
+        // When
         when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
                 .thenReturn(Flux.just(demat1, demat2));
 
@@ -160,10 +202,159 @@ class PNAG012MessageHandlerTest {
         PnEventMeta pnEventMetaPNAG012 = createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, 365L);
         when(eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)).thenReturn(Mono.empty());
 
+        // Then
         // eseguo l'handler
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
         verify(mockSqsSender, never()).pushSendEvent(any());
 
+    }
+
+    @Test
+    void blockedFlowBecauseRequestMissRequiredDemats() {
+        /* This method tests flow interruption because of missing 23L demat required.
+         * Test must be rejected because request does not have all required demats.
+         * */
+
+        // Given
+        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
+        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
+                .requestId("requestId")
+                .statusCode("RECAG012")
+                .statusDateTime(instant)
+                .clientRequestTimeStamp(instant)
+                .deliveryFailureCause("M02");
+
+        PnDeliveryRequest entity = new PnDeliveryRequest();
+        entity.setRequestId("requestId");
+        entity.setStatusCode("statusDetail");
+        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+
+        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+
+        PnEventDemat demat = new PnEventDemat();
+        demat.setDematRequestId(dematRequestId);
+        demat.setDocumentTypeStatusCode(DEMAT_ARCAD_RECAG011B);
+        demat.setStatusCode(RECAG011B_STATUS_CODE);
+        demat.setDocumentType(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType());
+
+        // When
+        /* Missing 23L demat must cause check failure */
+        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER)).thenReturn(Flux.just(demat));
+
+        // Then
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
+
+        verify(eventMetaDAO, never()).getDeliveryEventMeta(anyString(), anyString());
+        verify(eventMetaDAO, never()).putIfAbsent(any(PnEventMeta.class));
+        verify(mockSqsSender, never()).pushSendEvent(any(SendEvent.class));
+    }
+
+    @Test
+    void testFlowWithDocumentTypeAliasOk() {
+        /* This method tests the interchangeability between CAD and ARCAD using alias.
+         * Test must pass because CAD demat is present and ARCAD is required.
+         * */
+
+        // Given
+        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
+        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
+                .requestId("requestId")
+                .statusCode("RECAG012")
+                .statusDateTime(instant)
+                .clientRequestTimeStamp(instant)
+                .deliveryFailureCause("M02");
+
+        PnDeliveryRequest entity = new PnDeliveryRequest();
+        entity.setRequestId("requestId");
+        entity.setStatusCode("statusDetail");
+        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+
+        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+
+        PnEventDemat demat1 = new PnEventDemat();
+        demat1.setDematRequestId(dematRequestId);
+        demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+        demat1.setStatusCode(RECAG011B_STATUS_CODE);
+        demat1.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
+
+        /* CAD and ARCAD are interchangeable in PNAG012 flow using alias */
+        PnEventDemat demat2 = new PnEventDemat();
+        demat2.setDematRequestId(dematRequestId);
+        demat2.setDocumentTypeStatusCode(DEMAT_CAD_RECAG011B);
+        demat2.setStatusCode(RECAG011B_STATUS_CODE);
+        demat2.setDocumentType(DematDocumentTypeEnum.DEMAT_CAD.getDocumentType());
+
+        // When
+        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
+                .thenReturn(Flux.just(demat1, demat2));
+
+        String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
+        PnEventMeta pnEventMetaRECAG012 = buildPnEventMeta(paperRequest);
+        when(eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER))
+                .thenReturn(Mono.just(pnEventMetaRECAG012));
+
+        PnEventMeta pnEventMetaPNAG012 = createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, 365L);
+        when(eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)).thenReturn(Mono.just(pnEventMetaPNAG012));
+
+        // Then
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
+        verify(mockSqsSender, times(1)).pushSendEvent(any());
+    }
+
+    @Test
+    void testFlowWithEmptyRequiredDematsOk() {
+        /* This method tests the case in which required demats set is empty.
+         * Test must pass because empty set means no mandatory items.
+         * */
+
+        // Given
+        Set<String> requiredDemats = Collections.emptySet();
+        ReflectionTestUtils.setField(handler, "requiredDemats", requiredDemats);
+
+        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
+        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
+                .requestId("requestId")
+                .statusCode("RECAG012")
+                .statusDateTime(instant)
+                .clientRequestTimeStamp(instant)
+                .deliveryFailureCause("M02");
+
+        PnDeliveryRequest entity = new PnDeliveryRequest();
+        entity.setRequestId("requestId");
+        entity.setStatusCode("statusDetail");
+        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+
+        String dematRequestId = buildDematRequestId(paperRequest.getRequestId());
+
+        PnEventDemat demat1 = new PnEventDemat();
+        demat1.setDematRequestId(dematRequestId);
+        demat1.setDocumentTypeStatusCode(DEMAT_23L_RECAG011B);
+        demat1.setStatusCode(RECAG011B_STATUS_CODE);
+        demat1.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
+
+        /* CAD and ARCAD are interchangeable in PNAG012 flow using alias */
+        PnEventDemat demat2 = new PnEventDemat();
+        demat2.setDematRequestId(dematRequestId);
+        demat2.setDocumentTypeStatusCode(DEMAT_CAD_RECAG011B);
+        demat2.setStatusCode(RECAG011B_STATUS_CODE);
+        demat2.setDocumentType(DematDocumentTypeEnum.DEMAT_CAD.getDocumentType());
+
+        // When
+        /* Missing 23L demat must cause check failure */
+        when(eventDematDAO.findAllByKeys(dematRequestId, DEMAT_SORT_KEYS_FILTER))
+                .thenReturn(Flux.just(demat1, demat2));
+
+        String metadataRequestIdFilter = buildMetaRequestId(paperRequest.getRequestId());
+        PnEventMeta pnEventMetaRECAG012 = buildPnEventMeta(paperRequest);
+        when(eventMetaDAO.getDeliveryEventMeta(metadataRequestIdFilter, META_SORT_KEY_FILTER))
+                .thenReturn(Mono.just(pnEventMetaRECAG012));
+
+        PnEventMeta pnEventMetaPNAG012 = createMETAForPNAG012Event(paperRequest, pnEventMetaRECAG012, 365L);
+        when(eventMetaDAO.putIfAbsent(pnEventMetaPNAG012)).thenReturn(Mono.just(pnEventMetaPNAG012));
+
+        // Then
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
+        verify(mockSqsSender, times(1)).pushSendEvent(any());
     }
 
     private PnEventMeta buildPnEventMeta(PaperProgressStatusEventDto paperRequest) {
@@ -185,6 +376,4 @@ class PNAG012MessageHandlerTest {
         pnEventMeta.setStatusDateTime(paperRequest.getStatusDateTime().toInstant());
         return pnEventMeta;
     }
-
-
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
@@ -106,7 +106,10 @@ class PNAG012MessageHandlerTest {
         // Then
         // eseguo l'handler
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
-        verify(mockSqsSender, times(1)).pushSendEvent(any());
+
+        verify(eventMetaDAO, times(1)).getDeliveryEventMeta(anyString(), anyString());
+        verify(eventMetaDAO, times(1)).putIfAbsent(any(PnEventMeta.class));
+        verify(mockSqsSender, times(1)).pushSendEvent(any(SendEvent.class));
 
     }
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
@@ -17,6 +17,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
+import java.util.HashSet;
 
 import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.*;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
@@ -39,7 +40,9 @@ class PNAG012MessageHandlerTest {
         eventDematDAO = mock(EventDematDAO.class);
         eventMetaDAO = mock(EventMetaDAO.class);
         mockSqsSender = mock(SqsSender.class);
-        handler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays);
+
+        // TODO: added new HashSet, implement test cases
+        handler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays, new HashSet<>());
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
@@ -11,6 +11,7 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 import it.pagopa.pn.paperchannel.middleware.queue.model.PNAG012Wrapper;
 import it.pagopa.pn.paperchannel.service.SqsSender;
+import it.pagopa.pn.paperchannel.utils.DematDocumentTypeEnum;
 import it.pagopa.pn.paperchannel.utils.ExternalChannelCodeEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,11 +21,12 @@ import reactor.core.publisher.Mono;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.DEMAT_SORT_KEYS_FILTER;
 import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.META_SORT_KEY_FILTER;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.RECAG011B_STATUS_CODE;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.createMETAForPNAG012Event;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -48,8 +50,12 @@ class RECAG011BMessageHandlerTest {
         eventMetaDAO = mock(EventMetaDAO.class);
         mockSqsSender = mock(SqsSender.class);
 
-        // TODO: added new HashSet, implement test cases
-        PNAG012MessageHandler pnag012MessageHandler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays, new HashSet<>());
+        Set<String> requiredDemats = Set.of(
+                DematDocumentTypeEnum.DEMAT_23L.getDocumentType(),
+                DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType()
+        );
+
+        PNAG012MessageHandler pnag012MessageHandler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays, requiredDemats);
         handler = new RECAG011BMessageHandler(mockSqsSender, eventDematDAO, ttlDays, pnag012MessageHandler);
     }
 
@@ -84,8 +90,13 @@ class RECAG011BMessageHandlerTest {
 
         PnEventDemat pnEventDemat23L = new PnEventDemat();
         pnEventDemat23L.setDocumentTypeStatusCode("23L##RECAG011B");
+        pnEventDemat23L.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
+        pnEventDemat23L.setStatusCode(RECAG011B_STATUS_CODE);
+
         PnEventDemat pnEventDematARCAD = new PnEventDemat();
         pnEventDematARCAD.setDocumentTypeStatusCode("ARCAD##RECAG011B");
+        pnEventDematARCAD.setDocumentType(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType());
+        pnEventDematARCAD.setStatusCode(RECAG011B_STATUS_CODE);
 
         when(eventDematDAO.findAllByKeys("DEMAT##requestId", DEMAT_SORT_KEYS_FILTER)).thenReturn(
                 Flux.fromIterable(List.of(pnEventDemat23L, pnEventDematARCAD)));
@@ -151,7 +162,9 @@ class RECAG011BMessageHandlerTest {
 
         PnEventDemat pnEventDemat23L = new PnEventDemat();
         pnEventDemat23L.setDocumentTypeStatusCode("23L##RECAG011B");
-        //viene trovato solo 23L##RECAG011B, che non basta a soddisfare il filtro
+        pnEventDemat23L.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
+        pnEventDemat23L.setStatusCode(RECAG011B_STATUS_CODE);
+        //viene trovato solo 23L##RECAG011B, che non basta a soddisfare il filtro (vedere requiredDemats nell'init)
 
         when(eventDematDAO.findAllByKeys("DEMAT##requestId", DEMAT_SORT_KEYS_FILTER)).thenReturn(
                 Flux.fromIterable(List.of(pnEventDemat23L)));
@@ -210,8 +223,13 @@ class RECAG011BMessageHandlerTest {
 
         PnEventDemat pnEventDemat23L = new PnEventDemat();
         pnEventDemat23L.setDocumentTypeStatusCode("23L##RECAG011B");
+        pnEventDemat23L.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
+        pnEventDemat23L.setStatusCode(RECAG011B_STATUS_CODE);
+
         PnEventDemat pnEventDematARCAD = new PnEventDemat();
         pnEventDematARCAD.setDocumentTypeStatusCode("ARCAD##RECAG011B");
+        pnEventDematARCAD.setDocumentType(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType());
+        pnEventDematARCAD.setStatusCode(RECAG011B_STATUS_CODE);
 
         when(eventDematDAO.findAllByKeys("DEMAT##requestId", DEMAT_SORT_KEYS_FILTER)).thenReturn(
                 Flux.fromIterable(List.of(pnEventDemat23L, pnEventDematARCAD)));
@@ -271,8 +289,13 @@ class RECAG011BMessageHandlerTest {
 
         PnEventDemat pnEventDemat23L = new PnEventDemat();
         pnEventDemat23L.setDocumentTypeStatusCode("23L##RECAG011B");
+        pnEventDemat23L.setDocumentType(DematDocumentTypeEnum.DEMAT_23L.getDocumentType());
+        pnEventDemat23L.setStatusCode(RECAG011B_STATUS_CODE);
+
         PnEventDemat pnEventDematARCAD = new PnEventDemat();
         pnEventDematARCAD.setDocumentTypeStatusCode("ARCAD##RECAG011B");
+        pnEventDematARCAD.setDocumentType(DematDocumentTypeEnum.DEMAT_ARCAD.getDocumentType());
+        pnEventDematARCAD.setStatusCode(RECAG011B_STATUS_CODE);
 
         when(eventDematDAO.findAllByKeys("DEMAT##requestId", DEMAT_SORT_KEYS_FILTER)).thenReturn(
                 Flux.fromIterable(List.of(pnEventDemat23L, pnEventDematARCAD)));

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
@@ -20,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.HashSet;
 import java.util.List;
 
 import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.DEMAT_SORT_KEYS_FILTER;
@@ -47,7 +48,8 @@ class RECAG011BMessageHandlerTest {
         eventMetaDAO = mock(EventMetaDAO.class);
         mockSqsSender = mock(SqsSender.class);
 
-        PNAG012MessageHandler pnag012MessageHandler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays);
+        // TODO: added new HashSet, implement test cases
+        PNAG012MessageHandler pnag012MessageHandler = new PNAG012MessageHandler(mockSqsSender, eventDematDAO, ttlDays, eventMetaDAO, ttlDays, new HashSet<>());
         handler = new RECAG011BMessageHandler(mockSqsSender, eventDematDAO, ttlDays, pnag012MessageHandler);
     }
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -47,6 +47,9 @@ pn.paper-channel.refinement-duration=10d
 # 1970-01-01T00:00:00Z;AAR,2024-01-31T23:00:00Z;COMPLETE
 pn.paper-channel.date-charge-calculation-modes=1970-01-01T00:00:00Z;AAR,2024-01-01T00:00:00Z;COMPLETE
 
+# Variable that defines all the mandatory demats related (for now) only to PNAG012 events
+pn.paper-channel.required-demats=23L,ARCAD
+
 pn.paper-channel.RequestPaIdOverride = 15376371009
 
 # Runtime mode


### PR DESCRIPTION
## Issue Summary

Paper Channel configuration must be extended to allow checks on mandatory demats and provide the chance to change configuration without changing code implementation.

Moreover, it's necessary to implement an alias mechanism to perform equality checks on similar demats (e.g. ARCAD and CAD).

## Solution Description

1. Added DematDocumentTypeEnum class to collect all demat document types and provide aliasing utility
2. Implemented check on mandatory demats using subset theory; in particular a specific request can proceed with PNAG012 event if and only if `recag011bDocumentTypes.containsAll(requiredDemats)` and it means that `requiredDemats` is a subset of `recag011bDocumentTypes` (demats from request)

Implemented unit tests to verify the behaviors above.