### PR TITLE
PN-9757 - F24 generation including VAT

### DIFF
--- a/src/main/java/it/pagopa/pn/paperchannel/utils/costutils/CostUtils.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/costutils/CostUtils.java
@@ -1,0 +1,29 @@
+package it.pagopa.pn.paperchannel.utils.costutils;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Utility class that contains static methods related to cost calculus and adjustment.
+ * */
+public final class CostUtils {
+    private CostUtils(){}
+
+    /**
+     * This method add the percentage vat to cost value.
+     * It returns the cost with VAT if vat is not null, cost otherwise.
+     * Percentage formula is: cost + (cost * vat) / 100 mathematically equivalent to cost * (1 + vat/100)
+     *
+     * @param vat   the percentage vat to add to cost
+     * @param cost  the cost to calculate with vat
+     *
+     * @return      the cost with vat if vat is not null, cost itself otherwise
+     * */
+    public static Integer getCostWithVat(@Nullable Integer vat, @NotNull Integer cost) {
+
+        if (vat == null) return cost;
+
+        double costWithVat = cost.doubleValue() * (1 + vat.doubleValue() / 100);
+        return Math.toIntExact(Math.round(costWithVat));
+    }
+}

--- a/src/test/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImplTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImplTest.java
@@ -29,7 +29,8 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -43,6 +44,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static it.pagopa.pn.paperchannel.model.StatusDeliveryEnum.F24_WAITING;
 import static org.junit.jupiter.api.Assertions.*;
@@ -111,18 +113,7 @@ class F24ServiceImplTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {
-            "AAR, 5, 5, 10, NULL, 100, 110",
-            "AAR, 12, 12, 10, NULL, 100, 110",
-            "AAR, 12, 12, 0, NULL, NULL, NULL",
-            "AAR, 12, 12, NULL, NULL, NULL, NULL",
-            "AAR, 5, 5, 10, 22, 100, 132", // AAR with VAT
-            "COMPLETE, 5, 5, 10, NULL, 6400, 6410",
-            "COMPLETE, 1, 1, 10, NULL, 6200, 6210",
-            "COMPLETE, 4, 8, 0, NULL, NULL, NULL",
-            "COMPLETE, 4, 8, NULL, NULL, NULL, NULL",
-            "COMPLETE, 5, 5, 10, 22, 6400, 7818" // COMPLETE with VAT
-    }, nullValues = {"NULL"})
+    @MethodSource(value = "preparePDFTestCases")
     @DisplayName("testPreparePDFSuccess")
     void testPreparePDFSuccess(
             String calculationMode,
@@ -391,5 +382,39 @@ class F24ServiceImplTest {
 
             return pdDocument;
         }
+    }
+
+    /** 
+     * Build test argument cases for {@link F24ServiceImplTest#testPreparePDFSuccess}
+     * */
+    private static Stream<Arguments> preparePDFTestCases() {
+
+        /* Test cases for AAR date calculation mode */
+        Arguments aarTestCaseWithNoVat1 = Arguments.of("AAR", 5, 5, 10, null, 100, 110);
+        Arguments aarTestCaseWithNoVat2 = Arguments.of("AAR", 12, 12, 10, null, 100, 110);
+        Arguments aarTestCaseWithZeroCostAndNoVat = Arguments.of("AAR", 12, 12, 0, null, null, null);
+        Arguments aarTestCaseWithNoCostAndNoVat = Arguments.of("AAR", 12, 12, null, null, null, null);
+        Arguments aarTestCaseWithCostAndVat = Arguments.of("AAR", 5, 5, 10, 22, 100, 132);
+
+        /* Test cases for COMPLETE date calculation mode */
+        Arguments completeTestCaseWithNoVat1 = Arguments.of("COMPLETE", 5, 5, 10, null, 6400, 6410);
+        Arguments completeTestCaseWithNoVat2 = Arguments.of("COMPLETE", 1, 1, 10, null, 6200, 6210);
+        Arguments completeTestCaseWithZeroCostAndNoVat = Arguments.of("COMPLETE", 4, 8, 0, null, null, null);
+        Arguments completeTestCaseWithNoCostAndNoVat = Arguments.of("COMPLETE", 4, 8, null, null, null, null);
+        Arguments completeTestCaseWithCostAndVat = Arguments.of("COMPLETE", 5, 5, 10, 22, 6400, 7818);
+
+        return Stream.of(
+                aarTestCaseWithNoVat1,
+                aarTestCaseWithNoVat2,
+                aarTestCaseWithZeroCostAndNoVat,
+                aarTestCaseWithNoCostAndNoVat,
+                aarTestCaseWithCostAndVat,
+                completeTestCaseWithNoVat1,
+                completeTestCaseWithNoVat2,
+                completeTestCaseWithZeroCostAndNoVat,
+                completeTestCaseWithNoCostAndNoVat,
+                completeTestCaseWithCostAndVat
+        );
+
     }
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/utils/costutils/CostUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/utils/costutils/CostUtilsTest.java
@@ -1,0 +1,25 @@
+package it.pagopa.pn.paperchannel.utils.costutils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CostUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "22, 436, 532", // Round Up Test
+            "22, 397, 484", // Round Down Test
+            "22, 1000, 1220", // 22% VAT
+            "10, 1500, 1650", // 10% VAT
+            "0, 1500, 1500", // Test with 0% VAT
+            "NULL, 1500, 1500" // Test with null VAT
+    }, nullValues = {"NULL"})
+    void getCostWithVatTest(Integer vat, Integer cost, Integer expectedCostWithVat) {
+
+        Integer costWithVat = CostUtils.getCostWithVat(vat, cost);
+
+        Assertions.assertNotNull(costWithVat);
+        Assertions.assertEquals(expectedCostWithVat, costWithVat);
+    }
+}


### PR DESCRIPTION
## Issue Summary

Paper Channel must consider VAT when calculate the total cost to preparate the F24 document.

## Solution Description

1. Paper Channel receives the optional query param `vat` within the `f24set` attachment
2. Paper Channel uses the `vat` percentage to calculate the shipping analog cost only when specified, otherwise normal cost without vat is calculated
3. The totale cost including vat must not be stored in database

Implemented unit tests to verify the behaviors above.