### PR TITLE
feat(pn-9904): upgrade pn-commons dependency to 2.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>it.pagopa.pn</groupId>
             <artifactId>pn-commons</artifactId>
-            <version>2.2.0</version>
+            <version>2.2.7</version>
         </dependency>
         <dependency>
             <groupId>it.pagopa.pn</groupId>


### PR DESCRIPTION
Upgraded pn-commons dependency from 2.2.0 to 2.2.7

Now National Registry base client inherits retry strategy from pn-commons instead using a custom one