### PR TITLE
feat(pn-10151): save paId in pn-PaperRequestError table

### DIFF
--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/PaperRequestErrorDAO.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/PaperRequestErrorDAO.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface PaperRequestErrorDAO {
 
 
-    Mono<PnRequestError> created(String requestId, String error, String classType);
+    Mono<PnRequestError> created(PnRequestError pnRequestError);
 
     Mono<List<PnRequestError>>  findAll();
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/impl/PaperRequestErrorDAOImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/impl/PaperRequestErrorDAOImpl.java
@@ -27,15 +27,8 @@ public class PaperRequestErrorDAOImpl extends BaseDAO<PnRequestError> implements
                 awsPropertiesConfig.getDynamodbPaperRequestErrorTable(), PnRequestError.class);}
 
     @Override
-    public Mono<PnRequestError> created(String requestId, String error, String flowThrow) {
-        PnRequestError requestError = new PnRequestError();
-        requestError.setRequestId(requestId);
-        requestError.setError(error);
-        requestError.setCreated(Instant.now());
-        requestError.setAuthor(Const.PN_PAPER_CHANNEL);
-        requestError.setFlowThrow(flowThrow);
-
-        return Mono.fromFuture(this.put(requestError).thenApply(item -> requestError));
+    public Mono<PnRequestError> created(PnRequestError pnRequestError) {
+        return Mono.fromFuture(this.put(pnRequestError).thenApply(item -> pnRequestError));
     }
 
 

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/impl/PaperRequestErrorDAOImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/dao/impl/PaperRequestErrorDAOImpl.java
@@ -12,7 +12,6 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
-import java.time.Instant;
 import java.util.List;
 
 @Repository

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnRequestError.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnRequestError.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.paperchannel.middleware.db.entities;
 
 
+import it.pagopa.pn.paperchannel.utils.Const;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,12 +16,18 @@ import java.time.Instant;
 @ToString
 @NoArgsConstructor
 public class PnRequestError {
+
+    /* Columns */
     public static final String COL_REQUEST_ID = "requestId";
     public static final String COL_CREATED = "created";
+    public static final String COL_PA_ID = "paId";
     public static final String COL_ERROR_TYPE = "error";
-    public static final String AUTHOR_INDEX = "author-index";
     public static final String COL_FLOW_THROW = "flowThrow";
     public static final String COL_AUTHOR = "author";
+
+    /* Indexes */
+    public static final String AUTHOR_INDEX = "author-index";
+
 
     @Getter(onMethod = @__({@DynamoDbPartitionKey, @DynamoDbAttribute(COL_REQUEST_ID)}))
     public String requestId;
@@ -31,9 +38,64 @@ public class PnRequestError {
     @Getter(onMethod = @__({@DynamoDbSecondaryPartitionKey(indexNames = AUTHOR_INDEX), @DynamoDbAttribute(COL_AUTHOR)}))
     public String author;
 
+    @Getter(onMethod = @__({@DynamoDbAttribute(COL_PA_ID)}))
+    public String paId;
+
     @Getter(onMethod = @__({@DynamoDbAttribute(COL_ERROR_TYPE)}))
     public String error;
 
     @Getter(onMethod = @__({@DynamoDbAttribute(COL_FLOW_THROW)}))
     public String flowThrow;
+
+    public static PnRequestErrorBuilder builder() {
+        return new PnRequestErrorBuilder();
+    }
+
+    /* Builder class */
+    public static class PnRequestErrorBuilder {
+
+        private String requestId;
+        private String paId;
+        private String error;
+        private String flowThrow;
+
+        // Private constructor
+        private PnRequestErrorBuilder() {}
+
+        public PnRequestErrorBuilder requestId(String requestId) {
+            this.requestId = requestId;
+            return this;
+        }
+
+        public PnRequestErrorBuilder paId(String paId) {
+            this.paId = paId;
+            return this;
+        }
+
+        public PnRequestErrorBuilder error(String error) {
+            this.error = error;
+            return this;
+        }
+
+        public PnRequestErrorBuilder flowThrow(String flowThrow) {
+            this.flowThrow = flowThrow;
+            return this;
+        }
+
+        public PnRequestError build() {
+            PnRequestError pnRequestError = new PnRequestError();
+
+            pnRequestError.setRequestId(this.requestId);
+            pnRequestError.setPaId(this.paId);
+            pnRequestError.setError(this.error);
+            pnRequestError.setFlowThrow(this.flowThrow);
+
+            /* Auto-generated constant field values */
+            pnRequestError.setCreated(Instant.now());
+            pnRequestError.setAuthor(Const.PN_PAPER_CHANNEL);
+
+            return pnRequestError;
+        }
+
+    }
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandler.java
@@ -3,11 +3,14 @@ package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.middleware.db.dao.PaperRequestErrorDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.service.SqsSender;
 import it.pagopa.pn.paperchannel.utils.PnLogAudit;
 import reactor.core.publisher.Mono;
 
 public class NotRetryableErrorMessageHandler extends SendToDeliveryPushHandler {
+
+    private static final String FINISH_RETRY_EXTERNAL_CHANNEL_MESSAGE = "requestId = %s finish retry to External Channel";
 
     private final PaperRequestErrorDAO paperRequestErrorDAO;
 
@@ -19,15 +22,22 @@ public class NotRetryableErrorMessageHandler extends SendToDeliveryPushHandler {
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {
         PnLogAudit pnLogAudit = new PnLogAudit();
-        pnLogAudit.addsBeforeDiscard(entity.getIun(), String.format("requestId = %s finish retry to External Channel", entity.getRequestId()));
+        pnLogAudit.addsBeforeDiscard(entity.getIun(), String.format(FINISH_RETRY_EXTERNAL_CHANNEL_MESSAGE, entity.getRequestId()));
 
         return super.handleMessage(entity, paperRequest)
                 .doOnSuccess(pnRequestError -> {
-                    paperRequestErrorDAO.created(entity.getRequestId(), entity.getStatusCode(), entity.getStatusDetail());
-                    pnLogAudit.addsSuccessDiscard(entity.getIun(), String.format("requestId = %s finish retry to External Channel", entity.getRequestId()));
+
+                    PnRequestError requestError = PnRequestError.builder()
+                            .requestId(entity.getRequestId())
+                            .paId(entity.getRequestPaId())
+                            .error(entity.getStatusCode())
+                            .flowThrow(entity.getStatusDetail())
+                            .build();
+
+                    paperRequestErrorDAO.created(requestError);
+                    pnLogAudit.addsSuccessDiscard(entity.getIun(), String.format(FINISH_RETRY_EXTERNAL_CHANNEL_MESSAGE, entity.getRequestId()));
                 })
-                .doOnError(throwable -> pnLogAudit.addsFailDiscard(entity.getIun(), String.format("requestId = %s finish retry to External Channel", entity.getRequestId())))
+                .doOnError(throwable -> pnLogAudit.addsFailDiscard(entity.getIun(), String.format(FINISH_RETRY_EXTERNAL_CHANNEL_MESSAGE, entity.getRequestId())))
                 .then();
     }
-
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandler.java
@@ -62,6 +62,7 @@ public class RetryableErrorMessageHandler extends SendToDeliveryPushHandler {
 
             PnRequestError pnRequestError = PnRequestError.builder()
                     .requestId(entity.getRequestId())
+                    .paId(entity.getRequestPaId())
                     .error(EXTERNAL_CHANNEL_API_EXCEPTION.getMessage())
                     .flowThrow(EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name())
                     .build();

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandler.java
@@ -10,6 +10,7 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.AddressDAO;
 import it.pagopa.pn.paperchannel.middleware.db.dao.PaperRequestErrorDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.middleware.msclient.ExternalChannelClient;
 import it.pagopa.pn.paperchannel.middleware.queue.model.EventTypeEnum;
 import it.pagopa.pn.paperchannel.model.AttachmentInfo;
@@ -28,6 +29,8 @@ import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.EXTERNAL_CHA
 @Slf4j
 //@RequiredArgsConstructor
 public class RetryableErrorMessageHandler extends SendToDeliveryPushHandler {
+
+    private static final String REQUEST_TO_EXTERNAL_CHANNEL = "prepare requestId = %s, trace_id = %s  request to External Channel";
 
     private final ExternalChannelClient externalChannelClient;
 
@@ -56,9 +59,16 @@ public class RetryableErrorMessageHandler extends SendToDeliveryPushHandler {
             return sendEngageRequest(entity, setRetryRequestId(paperRequest.getRequestId()))
                     .flatMap(pnDeliveryRequest -> super.handleMessage(entity, paperRequest));
         } else {
-            return paperRequestErrorDAO.created(entity.getRequestId(),
-                            EXTERNAL_CHANNEL_API_EXCEPTION.getMessage(), EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name())
-                    .flatMap(pnRequestError -> super.handleMessage(entity, paperRequest));
+
+            PnRequestError pnRequestError = PnRequestError.builder()
+                    .requestId(entity.getRequestId())
+                    .error(EXTERNAL_CHANNEL_API_EXCEPTION.getMessage())
+                    .flowThrow(EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name())
+                    .build();
+
+            return paperRequestErrorDAO
+                    .created(pnRequestError)
+                    .flatMap(requestError -> super.handleMessage(entity, paperRequest));
         }
 
     }
@@ -96,16 +106,16 @@ public class RetryableErrorMessageHandler extends SendToDeliveryPushHandler {
 
         SendRequest sendRequest = SendRequestMapper.toDto(pnAddresses, pnDeliveryRequest);
         sendRequest.setRequestId(requestId);
-        pnLogAudit.addsBeforeSend(sendRequest.getIun(), String.format("prepare requestId = %s, trace_id = %s  request to External Channel", sendRequest.getRequestId(), MDC.get(MDCUtils.MDC_TRACE_ID_KEY)));
+        pnLogAudit.addsBeforeSend(sendRequest.getIun(), String.format(REQUEST_TO_EXTERNAL_CHANNEL, sendRequest.getRequestId(), MDC.get(MDCUtils.MDC_TRACE_ID_KEY)));
 
         List<AttachmentInfo> attachmentInfos = pnDeliveryRequest.getAttachments().stream().map(AttachmentMapper::fromEntity).toList();
 
         return externalChannelClient.sendEngageRequest(sendRequest, attachmentInfos)
                 .doOnSuccess(unused -> pnLogAudit.addsSuccessSend(sendRequest.getIun(),
-                        String.format("prepare requestId = %s, trace_id = %s  request to External Channel", sendRequest.getRequestId(), MDC.get(MDCUtils.MDC_TRACE_ID_KEY)))
+                        String.format(REQUEST_TO_EXTERNAL_CHANNEL, sendRequest.getRequestId(), MDC.get(MDCUtils.MDC_TRACE_ID_KEY)))
                 )
                 .doOnError(ex ->
-                    pnLogAudit.addsWarningSend(sendRequest.getIun(), String.format("prepare requestId = %s, trace_id = %s  request to External Channel", sendRequest.getRequestId(), MDC.get(MDCUtils.MDC_TRACE_ID_KEY)))
+                    pnLogAudit.addsWarningSend(sendRequest.getIun(), String.format(REQUEST_TO_EXTERNAL_CHANNEL, sendRequest.getRequestId(), MDC.get(MDCUtils.MDC_TRACE_ID_KEY)))
                 )
                 .thenReturn(pnDeliveryRequest);
 

--- a/src/main/java/it/pagopa/pn/paperchannel/service/impl/PrepareAsyncServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/service/impl/PrepareAsyncServiceImpl.java
@@ -14,6 +14,7 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.PaperRequestErrorDAO;
 import it.pagopa.pn.paperchannel.middleware.db.dao.RequestDeliveryDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.middleware.msclient.NationalRegistryClient;
 import it.pagopa.pn.paperchannel.model.*;
 import it.pagopa.pn.paperchannel.service.*;
@@ -268,8 +269,14 @@ public class PrepareAsyncServiceImpl extends BaseService implements PaperAsyncSe
     }
 
     private Mono<Void> traceError(String requestId, String error, String flowType){
-        return this.paperRequestErrorDAO.created(requestId, error, flowType)
-                .then();
+
+        PnRequestError pnRequestError = PnRequestError.builder()
+                .requestId(requestId)
+                .error(error)
+                .flowThrow(flowType)
+                .build();
+
+        return this.paperRequestErrorDAO.created(pnRequestError).then();
     }
 
     private void pushPrepareEvent(PnDeliveryRequest request, Address address, String clientId, StatusCodeEnum statusCode, KOReason koReason){

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/PaperRequestErrorDAOTestIT.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/PaperRequestErrorDAOTestIT.java
@@ -16,12 +16,19 @@ class PaperRequestErrorDAOTestIT extends BaseTest {
 
     @Test
     void createRequestErrorTest(){
-        String requestId = "id-1234";
-        String error = "errore test";
-        String classType = "java";
-        PnRequestError requestError = this.paperRequestErrorDAO.created(requestId, error, classType).block();
-        assertNotNull(requestError);
 
+        // Given
+        PnRequestError pnRequestError = PnRequestError.builder()
+                .requestId("id-1234")
+                .error("errore test")
+                .flowThrow("java")
+                .build();
+
+        // When
+        PnRequestError requestError = this.paperRequestErrorDAO.created(pnRequestError).block();
+
+        // Then
+        assertNotNull(requestError);
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnRequestErrorTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnRequestErrorTest.java
@@ -16,6 +16,7 @@ class PnRequestErrorTest {
     public String error;
     public String flowThrow;
     public String author;
+    public String paId;
 
     @BeforeEach
     void setUp(){
@@ -37,6 +38,9 @@ class PnRequestErrorTest {
         stringBuilder.append("author=");
         stringBuilder.append(author);
         stringBuilder.append(", ");
+        stringBuilder.append("paId=");
+        stringBuilder.append(paId);
+        stringBuilder.append(", ");
         stringBuilder.append("error=");
         stringBuilder.append(error);
         stringBuilder.append(", ");
@@ -55,6 +59,7 @@ class PnRequestErrorTest {
         pnRequestError.setAuthor(author);
         pnRequestError.setError(error);
         pnRequestError.setFlowThrow(flowThrow);
+        pnRequestError.setPaId(paId);
         return pnRequestError;
     }
 
@@ -64,5 +69,6 @@ class PnRequestErrorTest {
         author= Const.PN_PAPER_CHANNEL;
         error = EXTERNAL_CHANNEL_LISTENER_EXCEPTION.getMessage();
         flowThrow = EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name();
+        paId = "0123456789";
     }
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/QueueListenerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/QueueListenerTest.java
@@ -115,6 +115,8 @@ class QueueListenerTest {
 
     @Test
     void internalQueueEventNationalRegNoAttempsTest(){
+
+        // Given
         String json = """
                 {
                     "correlationId": "abc",
@@ -126,15 +128,19 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-04-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "4");
         PnRequestError requestError = new PnRequestError();
-        when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(requestError));
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(requestError));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
     @Test
     void internalQueueEventNationalRegExpiredTest(){
-        Mockito.when(paperRequestErrorDAO.created("NRTK-EWZL-KVPV-202212-Q-1124ds", "ERROR WITH RETRIEVE ADDRESS",
-                EventTypeEnum.NATIONAL_REGISTRIES_ERROR.name())).thenReturn(Mono.just(new PnRequestError()));
+
+        // Given
         String json = """
                 {
                     "correlationId": "abc",
@@ -145,12 +151,19 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.NATIONAL_REGISTRIES_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2030-04-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
+
+        // When
+        Mockito.when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
     @Test
     void internalQueueEventNationalRegistryErrorTest(){
+
+        // Given
         String json = """
                 {
                     "correlationId": "abc",
@@ -161,8 +174,12 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.NATIONAL_REGISTRIES_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-02-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        Mockito.when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(new PnRequestError()));
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
@@ -191,6 +208,8 @@ class QueueListenerTest {
 
     @Test
     void internalQueueEventF24ErrorTest(){
+
+        // Given
         String json = """
                 {
                     "correlationId": "abc",
@@ -201,14 +220,20 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.F24_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-02-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        Mockito.when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(new PnRequestError()));
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
 
     @Test
     void internalQueueEventExternalChannelJsonBadlyTest(){
+
+        // Given
         String json = """
                 {
                     correlationId: null,
@@ -219,75 +244,18 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-04-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        PnGenericException exception = assertThrows(PnGenericException.class, () ->{
-            queueListener.pullFromInternalQueue(json, headers);
-        });
+
+        // When
+        PnGenericException exception = assertThrows(PnGenericException.class, () -> queueListener.pullFromInternalQueue(json, headers));
+
+        // Then
         assertEquals(MAPPER_ERROR, exception.getExceptionType());
     }
 
     @Test
     void internalQueueEventExternalChannelNoAttempsTest(){
-        String json = """
-                {
-                     "digitalCourtesy": null,
-                     "digitalLegal": null,
-                     "analogMail": 
-                     {
-                        "requestId": "AKUZ-AWPL-LTPX-20230415",
-                        "registeredLetterCode": null, 
-                        "productType": "AR",
-                        "iun": "AKUZ-AWPL-LTPX-20230415",
-                        "statusCode": "002",
-                        "statusDescription": "Mock status",
-                        "statusDateTime": "2023-01-12T14:35:35.135725152Z",
-                        "deliveryFailureCause": null,
-                        "attachments": null,
-                        "discoveredAddress": null,
-                        "clientRequestTimeStamp": "2023-01-12T14:35:35.13572075Z"
-                     }
-                }""";
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name());
-        headers.put(PN_EVENT_HEADER_EXPIRED, "2023-04-12T14:35:35.135725152Z");
-        headers.put(PN_EVENT_HEADER_ATTEMPT, "4");
-        PnRequestError requestError = new PnRequestError();
-        when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(requestError));
-        queueListener.pullFromInternalQueue(json, headers);
-        assertTrue(true);
-    }
 
-    @Test
-    void internalQueueEventExternalChannelExpiredTest(){
-        String json = """
-                {
-                     "digitalCourtesy": null,
-                     "digitalLegal": null,
-                     "analogMail": 
-                     {
-                        "requestId": "AKUZ-AWPL-LTPX-20230415",
-                        "registeredLetterCode": null, 
-                        "productType": "AR",
-                        "iun": "AKUZ-AWPL-LTPX-20230415",
-                        "statusCode": "002",
-                        "statusDescription": "Mock status",
-                        "statusDateTime": "2023-01-12T14:35:35.135725152Z",
-                        "deliveryFailureCause": null,
-                        "attachments": null,
-                        "discoveredAddress": null,
-                        "clientRequestTimeStamp": "2023-01-12T14:35:35.13572075Z"
-                     }
-                }""";
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name());
-        headers.put(PN_EVENT_HEADER_EXPIRED, "2030-04-12T14:35:35.135725152Z");
-        headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        Mockito.when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(new PnRequestError()));
-        queueListener.pullFromInternalQueue(json, headers);
-        assertTrue(true);
-    }
-
-    @Test
-    void internalQueueEventExternalChannelErrorTest(){
+        // Given
         String json = """
                 {
                      "digitalCourtesy": null,
@@ -295,7 +263,80 @@ class QueueListenerTest {
                      "analogMail":
                      {
                         "requestId": "AKUZ-AWPL-LTPX-20230415",
-                        "registeredLetterCode": null, 
+                        "registeredLetterCode": null,
+                        "productType": "AR",
+                        "iun": "AKUZ-AWPL-LTPX-20230415",
+                        "statusCode": "002",
+                        "statusDescription": "Mock status",
+                        "statusDateTime": "2023-01-12T14:35:35.135725152Z",
+                        "deliveryFailureCause": null,
+                        "attachments": null,
+                        "discoveredAddress": null,
+                        "clientRequestTimeStamp": "2023-01-12T14:35:35.13572075Z"
+                     }
+                }""";
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name());
+        headers.put(PN_EVENT_HEADER_EXPIRED, "2023-04-12T14:35:35.135725152Z");
+        headers.put(PN_EVENT_HEADER_ATTEMPT, "4");
+        PnRequestError requestError = new PnRequestError();
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(requestError));
+        queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
+        assertTrue(true);
+    }
+
+    @Test
+    void internalQueueEventExternalChannelExpiredTest(){
+
+        // Given
+        String json = """
+                {
+                     "digitalCourtesy": null,
+                     "digitalLegal": null,
+                     "analogMail":
+                     {
+                        "requestId": "AKUZ-AWPL-LTPX-20230415",
+                        "registeredLetterCode": null,
+                        "productType": "AR",
+                        "iun": "AKUZ-AWPL-LTPX-20230415",
+                        "statusCode": "002",
+                        "statusDescription": "Mock status",
+                        "statusDateTime": "2023-01-12T14:35:35.135725152Z",
+                        "deliveryFailureCause": null,
+                        "attachments": null,
+                        "discoveredAddress": null,
+                        "clientRequestTimeStamp": "2023-01-12T14:35:35.13572075Z"
+                     }
+                }""";
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name());
+        headers.put(PN_EVENT_HEADER_EXPIRED, "2030-04-12T14:35:35.135725152Z");
+        headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
+        queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
+        assertTrue(true);
+    }
+
+    @Test
+    void internalQueueEventExternalChannelErrorTest(){
+
+        // Given
+        String json = """
+                {
+                     "digitalCourtesy": null,
+                     "digitalLegal": null,
+                     "analogMail":
+                     {
+                        "requestId": "AKUZ-AWPL-LTPX-20230415",
+                        "registeredLetterCode": null,
                         "productType": "AR",
                         "iun": "AKUZ-AWPL-LTPX-20230415",
                         "statusCode": "002",
@@ -311,13 +352,19 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-02-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        Mockito.when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(new PnRequestError()));
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
     @Test
     void internalQueueEventSafeStorageJsonBadlyTest(){
+
+        // Given
         String json = """
                 {
                     correlationId: null,
@@ -328,22 +375,26 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.SAFE_STORAGE_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-04-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        PnGenericException exception = assertThrows(PnGenericException.class, () ->{
-            queueListener.pullFromInternalQueue(json, headers);
-        });
+
+        // When
+        PnGenericException exception = assertThrows(PnGenericException.class, () -> queueListener.pullFromInternalQueue(json, headers));
+
+        // Then
         assertEquals(MAPPER_ERROR, exception.getExceptionType());
     }
 
     @Test
     void internalQueueEventSafeStorageNoAttempsTest(){
+
+        // Given
         String json = """
                 {
                      "digitalCourtesy": null,
                      "digitalLegal": null,
-                     "analogMail": 
+                     "analogMail":
                      {
                         "requestId": "AKUZ-AWPL-LTPX-20230415",
-                        "registeredLetterCode": null, 
+                        "registeredLetterCode": null,
                         "productType": "AR",
                         "iun": "AKUZ-AWPL-LTPX-20230415",
                         "statusCode": "002",
@@ -360,21 +411,27 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-04-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "4");
         PnRequestError requestError = new PnRequestError();
-        when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(requestError));
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(requestError));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
     @Test
     void internalQueueEventSafeStorageExpiredTest(){
+
+        // Given
         String json = """
                 {
                      "digitalCourtesy": null,
                      "digitalLegal": null,
-                     "analogMail": 
+                     "analogMail":
                      {
                         "requestId": "AKUZ-AWPL-LTPX-20230415",
-                        "registeredLetterCode": null, 
+                        "registeredLetterCode": null,
                         "productType": "AR",
                         "iun": "AKUZ-AWPL-LTPX-20230415",
                         "statusCode": "002",
@@ -390,21 +447,27 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.SAFE_STORAGE_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2030-04-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        Mockito.when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(new PnRequestError()));
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
     @Test
     void internalQueueEventSafeStorageErrorTest(){
+
+        // Given
         String json = """
                 {
                      "digitalCourtesy": null,
                      "digitalLegal": null,
-                     "analogMail": 
+                     "analogMail":
                      {
                         "requestId": "AKUZ-AWPL-LTPX-20230415",
-                        "registeredLetterCode": null, 
+                        "registeredLetterCode": null,
                         "productType": "AR",
                         "iun": "AKUZ-AWPL-LTPX-20230415",
                         "statusCode": "002",
@@ -420,8 +483,12 @@ class QueueListenerTest {
         headers.put(PN_EVENT_HEADER_EVENT_TYPE, EventTypeEnum.SAFE_STORAGE_ERROR.name());
         headers.put(PN_EVENT_HEADER_EXPIRED, "2023-02-12T14:35:35.135725152Z");
         headers.put(PN_EVENT_HEADER_ATTEMPT, "0");
-        Mockito.when(paperRequestErrorDAO.created(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Mono.just(new PnRequestError()));
+
+        // When
+        when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
         queueListener.pullFromInternalQueue(json, headers);
+
+        // Then
         assertTrue(true);
     }
 
@@ -482,10 +549,10 @@ class QueueListenerTest {
                 {
                      "digitalCourtesy": null,
                      "digitalLegal": null,
-                     "analogMail": 
+                     "analogMail":
                      {
                         "requestId": "AKUZ-AWPL-LTPX-20230415",
-                        "registeredLetterCode": null, 
+                        "registeredLetterCode": null,
                         "productType": "AR",
                         "iun": "AKUZ-AWPL-LTPX-20230415",
                         "statusCode": "002",
@@ -507,9 +574,9 @@ class QueueListenerTest {
                 {
                      digitalCourtesy: null,
                      "digitalLegal": null,
-                     "analogMail": 
+                     "analogMail":
                      {
-                        "registeredLetterCode": null, 
+                        "registeredLetterCode": null,
                         "productType": "AR",
                         "iun": "AKUZ-AWPL-LTPX-20230415",
                         "statusCode": "002",

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/QueueListenerTestIT.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/QueueListenerTestIT.java
@@ -78,7 +78,7 @@ class QueueListenerTestIT extends BaseTest
         when(requestDeliveryDAO.updateData(pnDeliveryRequest)).thenReturn(Mono.just(pnDeliveryRequest));
         when(addressDAO.findAllByRequestId(requestId)).thenReturn(Mono.just(createAddresses()));
         when(externalChannelClient.sendEngageRequest(any(), any())).thenReturn(Mono.error(WebClientResponseException.create(400, "", new HttpHeaders(), null, Charset.defaultCharset())));
-        when(paperRequestErrorDAO.created(anyString(), anyString(), anyString())).thenReturn(Mono.just(new PnRequestError()));
+        when(paperRequestErrorDAO.created(any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
 
         //invio il messaggio nella coda di ext-channel
         final String messageJson = toJson(messagePayload);
@@ -93,7 +93,7 @@ class QueueListenerTestIT extends BaseTest
                 .untilAsserted(() -> verify(queueListenerService, times(2)).externalChannelListener(any(), anyInt()));
 
         //mi aspetto che non cia mai invocato il salvataggio della PaperError
-        verify(paperRequestErrorDAO, never()).created(anyString(), anyString(), anyString());
+        verify(paperRequestErrorDAO, never()).created(any(PnRequestError.class));
 
         //mi aspetto che dopo aver letto il messaggio 2 volte, quest'ultimo venga re-indirizzato in DLQ
         await()

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandlerTest.java
@@ -38,6 +38,8 @@ class NotRetryableErrorMessageHandlerTest {
         entity.setRequestId("requestId");
         entity.setStatusCode(StatusCodeEnum.PROGRESS.getValue());
         entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+        entity.setRequestPaId("0123456789");
+
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -58,6 +60,12 @@ class NotRetryableErrorMessageHandlerTest {
         // Then
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 
-        verify(paperRequestErrorDAOMock, timeout(1000).times(1)).created(Mockito.any(PnRequestError.class));
+        verify(paperRequestErrorDAOMock, timeout(1000).times(1))
+                .created(argThat(requestError ->
+                    requestError.getRequestId().equals(entity.getRequestId()) &&
+                    requestError.getPaId().equals(entity.getRequestPaId()) &&
+                    requestError.getError().equals(entity.getStatusCode()) &&
+                    requestError.getFlowThrow().equals(entity.getStatusDetail())
+                ));
     }
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableWithoutSendErrorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableWithoutSendErrorMessageHandlerTest.java
@@ -7,18 +7,17 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import reactor.core.publisher.Mono;
-
-import java.time.OffsetDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.*;
 
 class NotRetryableWithoutSendErrorMessageHandlerTest {
-    @Autowired
+
     private NotRetriableWithoutSendErrorMessageHandler handler;
+
     @MockBean
     private PaperRequestErrorDAO paperRequestErrorDAOMock;
 
@@ -30,22 +29,24 @@ class NotRetryableWithoutSendErrorMessageHandlerTest {
 
     @Test
     void handleMessageTest() {
+
+        // Given
         PnDeliveryRequest entity = new PnDeliveryRequest();
         entity.setRequestId("requestId");
         entity.setStatusCode(StatusCodeEnum.PROGRESS.getValue());
         entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
-        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
+
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto();
         PnRequestError requestError = new PnRequestError();
         requestError.setRequestId("requestId");
 
-        when(paperRequestErrorDAOMock.created(anyString(), anyString(), anyString()))
-                .thenReturn(Mono.just(requestError));
+        // When
+        when(paperRequestErrorDAOMock.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(requestError));
 
+        // Then
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 
-        verify(paperRequestErrorDAOMock, timeout(1000).times(1))
-                .created("requestId", StatusCodeEnum.PROGRESS.getValue(), StatusCodeEnum.PROGRESS.getValue());
+        verify(paperRequestErrorDAOMock, timeout(1000).times(1)).created(Mockito.any(PnRequestError.class));
     }
 }
 

--- a/src/test/java/it/pagopa/pn/paperchannel/service/PrepareAsyncServiceTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/service/PrepareAsyncServiceTest.java
@@ -20,6 +20,7 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.RequestDeliveryDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnAttachmentInfo;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
+import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.middleware.msclient.AddressManagerClient;
 import it.pagopa.pn.paperchannel.model.Address;
 import it.pagopa.pn.paperchannel.model.KOReason;
@@ -154,7 +155,7 @@ class PrepareAsyncServiceTest {
                 }).verify();
 
         // VERIFICO CHE IN QUESTO CASO NON VENGA MAI CREATO IL RECORD DI ERRORE
-        Mockito.verify(paperRequestErrorDAO, Mockito.never()).created(Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(paperRequestErrorDAO, Mockito.never()).created(Mockito.any(PnRequestError.class));
 
         // VERIFICO CHE È STATO INVIATO L'EVENTO DI KOUNREACHABLE A DELIVERY PUSH
         RequestDeliveryMapper.changeState(pnDeliveryRequest, StatusDeliveryEnum.UNTRACEABLE.getCode(),
@@ -311,7 +312,7 @@ class PrepareAsyncServiceTest {
             Mockito.verify(this.sqsSender).pushPrepareEvent(prepareEventArgumentCaptor.capture());
 
             // VERIFICO CHE IN QUESTO CASO NON VENGA MAI CREATO IL RECORD DI ERRORE
-            Mockito.verify(paperRequestErrorDAO, Mockito.never()).created(Mockito.any(), Mockito.any(), Mockito.any());
+            Mockito.verify(paperRequestErrorDAO, Mockito.never()).created(Mockito.any(PnRequestError.class));
 
             PrepareEvent prepareEventActual = prepareEventArgumentCaptor.getValue();
 

--- a/src/test/java/it/pagopa/pn/paperchannel/service/QueueListenerServiceImplTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/service/QueueListenerServiceImplTest.java
@@ -18,7 +18,6 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.middleware.msclient.ExternalChannelClient;
-import it.pagopa.pn.paperchannel.middleware.queue.model.EventTypeEnum;
 import it.pagopa.pn.paperchannel.model.F24Error;
 import it.pagopa.pn.paperchannel.model.PrepareAsyncRequest;
 import it.pagopa.pn.paperchannel.model.StatusDeliveryEnum;
@@ -199,7 +198,7 @@ class QueueListenerServiceImplTest {
         this.queueListenerService.nationalRegistriesResponseListener(addressSQSMessageDto);
 
         // Then
-        Mockito.verify(this.paperRequestErrorDAO, Mockito.never()).created(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(this.paperRequestErrorDAO, Mockito.never()).created(Mockito.any(PnRequestError.class));
         Mockito.verify(this.sqsSender, Mockito.times(1)).pushToInternalQueue(Mockito.any(PrepareAsyncRequest.class));
     }
 
@@ -228,7 +227,7 @@ class QueueListenerServiceImplTest {
         this.queueListenerService.nationalRegistriesResponseListener(addressSQSMessageDto);
 
         // Then
-        Mockito.verify(this.paperRequestErrorDAO, Mockito.never()).created(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(this.paperRequestErrorDAO, Mockito.never()).created(Mockito.any(PnRequestError.class));
         Mockito.verify(this.sqsSender, Mockito.times(1)).pushToInternalQueue(Mockito.any(PrepareAsyncRequest.class));
     }
 
@@ -257,7 +256,7 @@ class QueueListenerServiceImplTest {
         this.queueListenerService.nationalRegistriesResponseListener(addressSQSMessageDto);
 
         // Then
-        Mockito.verify(this.paperRequestErrorDAO, Mockito.never()).created(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(this.paperRequestErrorDAO, Mockito.never()).created(Mockito.any(PnRequestError.class));
         Mockito.verify(this.sqsSender, Mockito.never()).pushToInternalQueue(Mockito.any(PrepareAsyncRequest.class));
     }
 
@@ -464,7 +463,7 @@ class QueueListenerServiceImplTest {
 
         assertThatNoException().isThrownBy(() -> queueListenerService.manualRetryExternalChannel(requestid, pcRetry));
         Mockito.verify(requestDeliveryDAO, Mockito.times(1)).updateData(Mockito.any());
-        Mockito.verify(paperRequestErrorDAO, Mockito.never()).created(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(paperRequestErrorDAO, Mockito.never()).created(Mockito.any(PnRequestError.class));
     }
 
     @Test
@@ -480,10 +479,8 @@ class QueueListenerServiceImplTest {
         final PnAddress add = new PnAddress();
         add.setTypology(AddressTypeEnum.RECEIVER_ADDRESS.name());
 
-
         Mockito.when(requestDeliveryDAO.getByRequestId(requestid)).thenReturn(Mono.just(deliveryRequest));
-        Mockito.when(paperRequestErrorDAO.created(requestid, "Error message", EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name()))
-                .thenReturn(Mono.just(new PnRequestError()));
+        Mockito.when(paperRequestErrorDAO.created(Mockito.any(PnRequestError.class))).thenReturn(Mono.just(new PnRequestError()));
 
         Mockito.when(externalChannelClient.sendEngageRequest(Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.error(new NullPointerException("Error message")));
@@ -492,8 +489,7 @@ class QueueListenerServiceImplTest {
 
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> queueListenerService.manualRetryExternalChannel(requestid, pcRetry));
 
-        Mockito.verify(paperRequestErrorDAO, Mockito.times(1))
-                .created(requestid, "Error message", EventTypeEnum.EXTERNAL_CHANNEL_ERROR.name());
+        Mockito.verify(paperRequestErrorDAO, Mockito.times(1)).created(Mockito.any(PnRequestError.class));
     }
 
     private PnAddress getRelatedAddress(){


### PR DESCRIPTION
## Issue Summary
Everytime one of following cases happen the PaperError must be saved with the notification source **paId**:
- Error call from ExternaChannel: `sendEngageExternalChannel()`
- `NotRetryableErrorMessageHandler`
- `NotRetriableWithoutSendErrorMessageHandler`

## Solution Description
Added new field `String paId` within `PnRequestError` class along with a new inner builder class `PnRequestErrorBuilder` to manage object instantiation from outside in order to standardize object creation strategy.

Moreover, the method `PaperRequestErrorDAO#created` has been simplified in order to reduce method call complexity while creating new paper errors; in particular, the method must receive a `PnRequestError` object instead single fields as parameters.