### PR TITLE
Feature/PN-10515

### DIFF
--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
@@ -179,6 +179,11 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECRN015.name(), handler); // progress
 
         map.put(ExternalChannelCodeEnum.RECAG015.name(), handler); // progress
+
+        // send "inesito" events to delivery push as progresses
+        map.put(ExternalChannelCodeEnum.RECAG010.name(), handler);
+        map.put(ExternalChannelCodeEnum.RECRS010.name(), handler);
+        map.put(ExternalChannelCodeEnum.RECRN010.name(), handler);
     }
 
     private void addAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, AggregatorMessageHandler handler) {

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/ExternalChannelCodeEnum.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/ExternalChannelCodeEnum.java
@@ -85,7 +85,12 @@ public enum ExternalChannelCodeEnum {
     RECAG008B(Constants.PROGRESS),
 
     //890
-    RECAG011B(Constants.PROGRESS);
+    RECAG011B(Constants.PROGRESS),
+
+    // "Inesito" events, respectively for 890, RS and AR product types
+    RECAG010(Constants.PROGRESS),
+    RECRS010(Constants.PROGRESS),
+    RECRN010(Constants.PROGRESS);
 
     private final String message;
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/DirectlySendMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/DirectlySendMessageHandlerTest.java
@@ -8,10 +8,13 @@ import it.pagopa.pn.paperchannel.mapper.SendEventMapper;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.service.SqsSender;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.*;
@@ -28,74 +31,82 @@ class DirectlySendMessageHandlerTest {
         handler = new DirectlySendMessageHandler(mockSqsSender);
     }
 
-    @Test
-    void handleMessageTest_CON080() {
+    @ParameterizedTest
+    @MethodSource(value = "directlySendMessageHandlerTestCases")
+    void handleMessageTest(PaperProgressStatusEventDto paperProgressStatusEventDto) {
+
+        PnDeliveryRequest entity = new PnDeliveryRequest();
+        entity.setRequestId(paperProgressStatusEventDto.getRequestId());
+        entity.setStatusCode(paperProgressStatusEventDto.getStatusCode());
+        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+
+        assertDoesNotThrow(() -> handler.handleMessage(entity, paperProgressStatusEventDto).block());
+
+        // expect exactly one call to delivery push sqs queue
+        SendEvent sendEventExpected = SendEventMapper.createSendEventMessage(entity, paperProgressStatusEventDto);
+        verify(mockSqsSender, times(1)).pushSendEvent(sendEventExpected);
+    }
+
+    /**
+     * Build test argument cases for {@link DirectlySendMessageHandlerTest#handleMessageTest}
+     * */
+    private static Stream<Arguments> directlySendMessageHandlerTestCases() {
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
-        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
-                .requestId("requestId")
-                .statusCode("CON080")
-                .statusDateTime(instant)
-                .clientRequestTimeStamp(instant)
-                .attachments(List.of(new AttachmentDetailsDto()
+
+        /* Test inputs */
+        PaperProgressStatusEventDto con080ProgressStatusEventDto = buildPaperProgressStatusEventDto("CON080", instant,
+                List.of(new AttachmentDetailsDto()
                         .documentType("Plico")
                         .date(instant)
-                        .uri("https://safestorage.it"))
-                );
+                        .uri("https://safestorage.it")
+                )
+        );
 
-        PnDeliveryRequest entity = new PnDeliveryRequest();
-        entity.setRequestId("requestId");
-        entity.setStatusCode("statusDetail");
-        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
+        PaperProgressStatusEventDto recri001ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRI001", instant, null);
+        PaperProgressStatusEventDto recri002ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRI002", instant, null);
+        PaperProgressStatusEventDto recrs001cProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRS001C", instant, null);
+        PaperProgressStatusEventDto recrs003cProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRS003C", instant, null);
+        PaperProgressStatusEventDto recrs015ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRS015", instant, null);
+        PaperProgressStatusEventDto recrn015ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRN015", instant, null);
+        PaperProgressStatusEventDto recag015ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECAG015", instant, null);
+        PaperProgressStatusEventDto recag010ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECAG010", instant, null);
+        PaperProgressStatusEventDto recrs010ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRS010", instant, null);
+        PaperProgressStatusEventDto recrn010ProgressStatusEventDto = buildPaperProgressStatusEventDto("RECRN010", instant, null);
 
-        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
+        /* Test method arguments */
+        Arguments con080ProgressStatusEventArguments = Arguments.of(con080ProgressStatusEventDto);
+        Arguments recri001ProgressStatusEventArguments = Arguments.of(recri001ProgressStatusEventDto);
+        Arguments recri002ProgressStatusEventArguments = Arguments.of(recri002ProgressStatusEventDto);
+        Arguments recrs001cProgressStatusEventArguments = Arguments.of(recrs001cProgressStatusEventDto);
+        Arguments recrs003cProgressStatusEventArguments = Arguments.of(recrs003cProgressStatusEventDto);
+        Arguments recrs015ProgressStatusEventArguments = Arguments.of(recrs015ProgressStatusEventDto);
+        Arguments recrn015ProgressStatusEventArguments = Arguments.of(recrn015ProgressStatusEventDto);
+        Arguments recag015ProgressStatusEventArguments = Arguments.of(recag015ProgressStatusEventDto);
+        Arguments recag010ProgressStatusEventArguments = Arguments.of(recag010ProgressStatusEventDto);
+        Arguments recrs010ProgressStatusEventArguments = Arguments.of(recrs010ProgressStatusEventDto);
+        Arguments recrn010ProgressStatusEventArguments = Arguments.of(recrn010ProgressStatusEventDto);
 
-        //mi aspetto che mandi il messaggio a delivery-push
-        SendEvent sendEventExpected = SendEventMapper.createSendEventMessage(entity, paperRequest);
-        verify(mockSqsSender, times(1)).pushSendEvent(sendEventExpected);
+        return Stream.of(
+                con080ProgressStatusEventArguments,
+                recri001ProgressStatusEventArguments,
+                recri002ProgressStatusEventArguments,
+                recrs001cProgressStatusEventArguments,
+                recrs003cProgressStatusEventArguments,
+                recrs015ProgressStatusEventArguments,
+                recrn015ProgressStatusEventArguments,
+                recag015ProgressStatusEventArguments,
+                recag010ProgressStatusEventArguments,
+                recrs010ProgressStatusEventArguments,
+                recrn010ProgressStatusEventArguments
+        );
     }
 
-
-    @Test
-    void handleMessageTest_RECRI001() {
-        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
-        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
+    private static PaperProgressStatusEventDto buildPaperProgressStatusEventDto(String statusCode, OffsetDateTime instant, List<AttachmentDetailsDto> attachmentDetailsDtoList) {
+        return new PaperProgressStatusEventDto()
                 .requestId("requestId")
-                .statusCode("RECRI001")
+                .statusCode(statusCode)
                 .statusDateTime(instant)
                 .clientRequestTimeStamp(instant)
-                ;
-
-        PnDeliveryRequest entity = new PnDeliveryRequest();
-        entity.setRequestId("requestId");
-        entity.setStatusCode("statusDetail");
-        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
-
-        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
-
-        //mi aspetto che mandi il messaggio a delivery-push
-        SendEvent sendEventExpected = SendEventMapper.createSendEventMessage(entity, paperRequest);
-        verify(mockSqsSender, times(1)).pushSendEvent(sendEventExpected);
-    }
-
-    @Test
-    void handleMessageTest_RECRI002() {
-        OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
-        PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
-                .requestId("requestId")
-                .statusCode("RECRI002")
-                .statusDateTime(instant)
-                .clientRequestTimeStamp(instant)
-                ;
-
-        PnDeliveryRequest entity = new PnDeliveryRequest();
-        entity.setRequestId("requestId");
-        entity.setStatusCode("statusDetail");
-        entity.setStatusDetail(StatusCodeEnum.PROGRESS.getValue());
-
-        assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
-
-        //mi aspetto che mandi il messaggio a delivery-push
-        SendEvent sendEventExpected = SendEventMapper.createSendEventMessage(entity, paperRequest);
-        verify(mockSqsSender, times(1)).pushSendEvent(sendEventExpected);
+                .attachments(attachmentDetailsDtoList);
     }
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactoryTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactoryTest.java
@@ -2,7 +2,12 @@ package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
 import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -18,38 +23,59 @@ class HandlersFactoryTest {
         handlersFactory.initializeHandlers();
     }
 
-    @Test
-    void getHandlerTest() {
-        MessageHandler con080Event = handlersFactory.getHandler("CON080");
-        MessageHandler recri001Event = handlersFactory.getHandler("RECRI001");
-        MessageHandler recri002Event = handlersFactory.getHandler("RECRI002");
-        MessageHandler preEsitoEvent = handlersFactory.getHandler("RECRS002A");
-        MessageHandler dematEvent = handlersFactory.getHandler("RECRS002B");
-        MessageHandler fascicoloChiuso = handlersFactory.getHandler("RECRS002C");
-        MessageHandler retryableErrorEventChiuso = handlersFactory.getHandler("RECRS006");
-        MessageHandler notRetryableErrorEventChiuso = handlersFactory.getHandler("CON998");
-        MessageHandler unknownEvent = handlersFactory.getHandler("UNKNOWN");
-        MessageHandler recag012 = handlersFactory.getHandler("RECAG012");
-        MessageHandler recag011B = handlersFactory.getHandler("RECAG011B");
-        MessageHandler recag005CEvent = handlersFactory.getHandler("RECAG005C");
-        MessageHandler recag006C = handlersFactory.getHandler("RECAG006C");
-        MessageHandler recag007C = handlersFactory.getHandler("RECAG007C");
+    @ParameterizedTest
+    @MethodSource(value = "getHandlerTestCases")
+    void getHandlerTest(List<String> progressStatusEventCodes, Class<? extends MessageHandler> clazz) {
 
-        assertThat(con080Event).isInstanceOf(DirectlySendMessageHandler.class);
-        assertThat(recri001Event).isInstanceOf(DirectlySendMessageHandler.class);
-        assertThat(recri002Event).isInstanceOf(DirectlySendMessageHandler.class);
-        assertThat(preEsitoEvent).isInstanceOf(SaveMetadataMessageHandler.class);
-        assertThat(dematEvent).isInstanceOf(SaveDematMessageHandler.class);
-        assertThat(fascicoloChiuso).isInstanceOf(AggregatorMessageHandler.class);
-        assertThat(retryableErrorEventChiuso).isInstanceOf(RetryableErrorMessageHandler.class);
-        assertThat(notRetryableErrorEventChiuso).isInstanceOf(NotRetryableErrorMessageHandler.class);
-        assertThat(unknownEvent).isInstanceOf(LogMessageHandler.class);
-        assertThat(recag012).isInstanceOf(RECAG012MessageHandler.class);
-        assertThat(recag011B).isInstanceOf(RECAG011BMessageHandler.class);
-        assertThat(recag005CEvent)
-                .isInstanceOf(Complex890MessageHandler.class)
-                .isEqualTo(recag006C)
-                .isEqualTo(recag007C);
+        assertThat(progressStatusEventCodes)
+                .hasSizeGreaterThan(0)
+                .allMatch(statusCode -> clazz.isInstance(handlersFactory.getHandler(statusCode)));
     }
 
+    /**
+     * Build test argument cases for {@link HandlersFactoryTest#getHandlerTest}
+     * */
+    private static Stream<Arguments> getHandlerTestCases() {
+
+        /* Test inputs */
+        List<String> directlySendMessageCases = List.of(
+                "CON080", "RECRI001", "RECRI002", "RECRS001C", "RECRS003C",
+                "RECRS015", "RECRN015", "RECAG015", "RECAG010", "RECRS010", "RECRN010"
+        );
+
+        List<String> saveMetadataMessageCases = List.of("RECRS002A");
+        List<String> saveDematMessageCases = List.of("RECRS002B");
+        List<String> aggregatorMessageCases = List.of("RECRS002C");
+        List<String> retryableMessageCases = List.of("RECRS006");
+        List<String> notRetryableMessageCases = List.of("CON998");
+        List<String> logMessageCases = List.of("UNKNOWN");
+        List<String> recag012MessageCases = List.of("RECAG012");
+        List<String> recag011bMessageCases = List.of("RECAG011B");
+        List<String> complex890MessageCases = List.of("RECAG005C", "RECAG006C", "RECAG007C");
+
+        /* Test method arguments */
+        Arguments directlySendMessageCasesArguments = Arguments.of(directlySendMessageCases, DirectlySendMessageHandler.class);
+        Arguments saveMetadataMessageCasesArguments = Arguments.of(saveMetadataMessageCases, SaveMetadataMessageHandler.class);
+        Arguments saveDematMessageCasesArguments = Arguments.of(saveDematMessageCases, SaveDematMessageHandler.class);
+        Arguments aggregatorMessageCasesArguments = Arguments.of(aggregatorMessageCases, AggregatorMessageHandler.class);
+        Arguments retryableMessageCasesArguments = Arguments.of(retryableMessageCases, RetryableErrorMessageHandler.class);
+        Arguments notRetryableMessageCasesArguments = Arguments.of(notRetryableMessageCases, NotRetryableErrorMessageHandler.class);
+        Arguments logMessageCasesArguments = Arguments.of(logMessageCases, LogMessageHandler.class);
+        Arguments recag012MessageCasesArguments = Arguments.of(recag012MessageCases, RECAG012MessageHandler.class);
+        Arguments recag011bMessageCasesArguments = Arguments.of(recag011bMessageCases, RECAG011BMessageHandler.class);
+        Arguments complex890MessageCasesArguments = Arguments.of(complex890MessageCases, Complex890MessageHandler.class);
+
+        return Stream.of(
+                directlySendMessageCasesArguments,
+                saveMetadataMessageCasesArguments,
+                saveDematMessageCasesArguments,
+                aggregatorMessageCasesArguments,
+                retryableMessageCasesArguments,
+                notRetryableMessageCasesArguments,
+                logMessageCasesArguments,
+                recag012MessageCasesArguments,
+                recag011bMessageCasesArguments,
+                complex890MessageCasesArguments
+        );
+    }
 }


### PR DESCRIPTION
## Obiettivo
L'obiettivo è quello di inviare gli eventi di inesito come eventi di progress a delivery push, in modo che sia possibile visualizzarli all'interno della timeline.
Eventi di inesito:
- **RECAG010** (caso 890)
- **RECRS010** (caso raccomandata semplice - RS)
- **RECRN010** (caso raccomandata con ricevuta di ritorno - AR)

## Soluzione
Sono stati aggiunti i nuovi eventi di inesito all'interno della classe `ExternalChannelCodeEnum`.
Sono stati collegati i nuovi eventi di inesito, all'interno della classe `HandlersFactory`, con il message handler `DirectlySendMessageHandler`.

Implementati i test unitari specifici per il caso d'uso e sono stati rifattorizzate le classi `HandlersFactoryTest` e `DirectlySendMessageHandlerTest` per una maggiore leggibilità e semplicità nell'aggiungere casi di test aggiuntivi senza replicare codice.