### PR TITLE
Feature/pn 10513

### DIFF
--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnDeliveryRequest.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnDeliveryRequest.java
@@ -71,6 +71,8 @@ public class PnDeliveryRequest {
 
     public static final String COL_REWORK_NEEDED_COUNT = "reworkNeededCount";
 
+    public static final String COL_REFINED = "refined";
+
     @Getter(onMethod = @__({@DynamoDbPartitionKey,@DynamoDbAttribute(COL_REQUEST_ID)}))
     private String requestId;
 
@@ -141,5 +143,6 @@ public class PnDeliveryRequest {
     @Getter(onMethod = @__({@DynamoDbAttribute(COL_REWORK_NEEDED_COUNT)}))
     private Integer reworkNeededCount;
 
-
+    @Getter(onMethod = @__({@DynamoDbAttribute(COL_REFINED)}))
+    private Boolean refined;
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/AggregatorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/AggregatorMessageHandler.java
@@ -9,12 +9,13 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDiscoveredAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 import it.pagopa.pn.paperchannel.middleware.queue.consumer.MetaDematCleaner;
-import it.pagopa.pn.paperchannel.service.SqsSender;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.WRONG_EVENT_ORDER;
-import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaRequestId;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaStatusCode;
 
 // Alla ricezione di questi tipi di eventi, che sono finali per lo specifico prodotto, paper-channel dovrà:
 // recuperare l’evento di pre-esito correlato (mediante accesso puntuale su hashkey META##RequestID e sortKey META##statusCode)
@@ -24,17 +25,11 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 // cancellate le righe in tabella per legate al requestId per le entità META e DEMAT
 
 @Slf4j
+@SuperBuilder
 public class AggregatorMessageHandler extends SendToDeliveryPushHandler {
-    private final EventMetaDAO eventMetaDAO;
-    private final MetaDematCleaner metaDematCleaner;
 
-
-    public AggregatorMessageHandler(SqsSender sqsSender, EventMetaDAO eventMetaDAO, MetaDematCleaner metaDematCleaner) {
-        super(sqsSender);
-
-        this.eventMetaDAO = eventMetaDAO;
-        this.metaDematCleaner = metaDematCleaner;
-    }
+    protected final EventMetaDAO eventMetaDAO;
+    protected final MetaDematCleaner metaDematCleaner;
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/Complex890MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/Complex890MessageHandler.java
@@ -14,6 +14,7 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -62,6 +63,11 @@ public class Complex890MessageHandler extends SendToDeliveryPushHandler {
     private final EventMetaDAO eventMetaDAO;
     private final MetaDematCleaner metaDematCleaner;
     private final PnPaperChannelConfig pnPaperChannelConfig;
+
+    @PostConstruct
+    private void postConstruct() {
+        log.info("Refinement duration is {}", this.pnPaperChannelConfig.getRefinementDuration());
+    }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/CustomAggregatorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/CustomAggregatorMessageHandler.java
@@ -4,7 +4,6 @@ import it.pagopa.pn.paperchannel.exception.PnGenericException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.mapper.RequestDeliveryMapper;
-import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/CustomAggregatorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/CustomAggregatorMessageHandler.java
@@ -1,15 +1,12 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
-
 import it.pagopa.pn.paperchannel.exception.PnGenericException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.mapper.RequestDeliveryMapper;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
-import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
-import it.pagopa.pn.paperchannel.middleware.queue.consumer.MetaDematCleaner;
-import it.pagopa.pn.paperchannel.service.SqsSender;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
@@ -19,13 +16,8 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaRequestId;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaStatusCode;
 
 @Slf4j
+@SuperBuilder
 public class CustomAggregatorMessageHandler extends AggregatorMessageHandler {
-    private final EventMetaDAO eventMetaDAO;
-
-    public CustomAggregatorMessageHandler(SqsSender sqsSender, EventMetaDAO eventMetaDAO, MetaDematCleaner metaDematCleaner) {
-        super(sqsSender, eventMetaDAO, metaDematCleaner);
-        this.eventMetaDAO = eventMetaDAO;
-    }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/DirectlySendMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/DirectlySendMessageHandler.java
@@ -1,9 +1,9 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
-import it.pagopa.pn.paperchannel.service.SqsSender;
+import lombok.experimental.SuperBuilder;
 
-public class DirectlySendMessageHandler extends SendToDeliveryPushHandler {
-    public DirectlySendMessageHandler(SqsSender sqsSender) {
-        super(sqsSender);
-    }
-}
+/**
+ * Possiamo eliminare questa classe rendendo {@link SendToDeliveryPushHandler} non astratta?
+ * */
+@SuperBuilder
+public class DirectlySendMessageHandler extends SendToDeliveryPushHandler { }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
@@ -42,20 +42,20 @@ public class HandlersFactory {
 
     @PostConstruct
     public void initializeHandlers() {
-        
-        MessageHandler saveMetadataMessageHandler = SaveMetadataMessageHandler.builder()
+
+        SaveMetadataMessageHandler saveMetadataMessageHandler = SaveMetadataMessageHandler.builder()
                 .eventMetaDAO(eventMetaDAO)
                 .pnPaperChannelConfig(pnPaperChannelConfig)
                 .build();
-        
-        MessageHandler saveDematMessageHandler = SaveDematMessageHandler.builder()
+
+        SaveDematMessageHandler saveDematMessageHandler = SaveDematMessageHandler.builder()
                 .sqsSender(sqsSender)
                 .eventDematDAO(eventDematDAO)
                 .requestDeliveryDAO(requestDeliveryDAO)
                 .pnPaperChannelConfig(pnPaperChannelConfig)
                 .build();
-        
-        MessageHandler retryableErrorExtChannelsMessageHandler = RetryableErrorMessageHandler.builder()
+
+        RetryableErrorMessageHandler retryableErrorExtChannelsMessageHandler = RetryableErrorMessageHandler.builder()
                 .sqsSender(sqsSender)
                 .externalChannelClient(externalChannelClient)
                 .addressDAO(addressDAO)
@@ -63,32 +63,32 @@ public class HandlersFactory {
                 .requestDeliveryDAO(requestDeliveryDAO)
                 .pnPaperChannelConfig(pnPaperChannelConfig)
                 .build();
-        
-        MessageHandler notRetryableErrorMessageHandler = NotRetryableErrorMessageHandler.builder()
+
+        NotRetryableErrorMessageHandler notRetryableErrorMessageHandler = NotRetryableErrorMessageHandler.builder()
                 .sqsSender(sqsSender)
                 .paperRequestErrorDAO(paperRequestErrorDAO)
                 .requestDeliveryDAO(requestDeliveryDAO)
                 .build();
-        
-        MessageHandler notRetriableWithoutSendErrorMessageHandler = NotRetriableWithoutSendErrorMessageHandler.builder()
+
+        NotRetriableWithoutSendErrorMessageHandler notRetriableWithoutSendErrorMessageHandler = NotRetriableWithoutSendErrorMessageHandler.builder()
                 .paperRequestErrorDAO(paperRequestErrorDAO)
                 .build();
-        
-        MessageHandler customAggregatorMessageHandler = CustomAggregatorMessageHandler.builder()
+
+        CustomAggregatorMessageHandler customAggregatorMessageHandler = CustomAggregatorMessageHandler.builder()
                 .sqsSender(sqsSender)
                 .eventMetaDAO(eventMetaDAO)
                 .metaDematCleaner(metaDematCleaner)
                 .requestDeliveryDAO(requestDeliveryDAO)
                 .build();
-        
-        MessageHandler aggregatorMessageHandler = AggregatorMessageHandler.builder()
+
+        AggregatorMessageHandler aggregatorMessageHandler = AggregatorMessageHandler.builder()
                 .sqsSender(sqsSender)
                 .eventMetaDAO(eventMetaDAO)
                 .metaDematCleaner(metaDematCleaner)
                 .requestDeliveryDAO(requestDeliveryDAO)
                 .build();
-         
-        MessageHandler directlySendMessageHandler = DirectlySendMessageHandler.builder()
+
+        DirectlySendMessageHandler directlySendMessageHandler = DirectlySendMessageHandler.builder()
                 .sqsSender(sqsSender)
                 .requestDeliveryDAO(requestDeliveryDAO)
                 .build();
@@ -180,7 +180,7 @@ public class HandlersFactory {
         map.put("PNAG012", pnag012MessageHandler);
     }
 
-    private void addRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
+    private void addRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, RetryableErrorMessageHandler handler) {
         map.put(ExternalChannelCodeEnum.RECRS006.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRN006.name(), handler);
         map.put(ExternalChannelCodeEnum.RECAG004.name(), handler);
@@ -191,7 +191,7 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECAG013.name(), handler);
     }
 
-    private void addNotRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
+    private void addNotRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, NotRetryableErrorMessageHandler handler) {
         map.put(ExternalChannelCodeEnum.CON998.name(), handler);
         map.put(ExternalChannelCodeEnum.CON997.name(), handler);
         map.put(ExternalChannelCodeEnum.CON996.name(), handler);
@@ -199,11 +199,11 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.CON993.name(), handler);
     }
 
-    private void addNotRetryableErrorStatusCodeWithoutSend(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler){
+    private void addNotRetryableErrorStatusCodeWithoutSend(ConcurrentHashMap<String, MessageHandler> map, NotRetriableWithoutSendErrorMessageHandler handler){
         map.put(ExternalChannelCodeEnum.P010.name(), handler);
     }
 
-    private void addSaveMetadataStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
+    private void addSaveMetadataStatusCodes(ConcurrentHashMap<String, MessageHandler> map, SaveMetadataMessageHandler handler) {
         map.put("RECRS002A", handler);
         map.put("RECRS002D", handler);
         map.put("RECRS004A", handler);
@@ -228,7 +228,7 @@ public class HandlersFactory {
     }
 
 
-    private void addSaveDematStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
+    private void addSaveDematStatusCodes(ConcurrentHashMap<String, MessageHandler> map, SaveDematMessageHandler handler) {
         map.put(ExternalChannelCodeEnum.RECRS002B.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS002E.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS004B.name(), handler);
@@ -254,7 +254,7 @@ public class HandlersFactory {
 
     }
 
-    private void addDirectlySendStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
+    private void addDirectlySendStatusCodes(ConcurrentHashMap<String, MessageHandler> map, DirectlySendMessageHandler handler) {
 
 
         //caso CON080, RECRI001, RECRI002
@@ -277,7 +277,7 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECRN010.name(), handler);
     }
 
-    private void addAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
+    private void addAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, AggregatorMessageHandler handler) {
         map.put(ExternalChannelCodeEnum.RECRS002C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS002F.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS004C.name(), handler);
@@ -296,7 +296,7 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECRSI004C.name(), handler);
     }
 
-    private void addCustomAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler){
+    private void addCustomAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, CustomAggregatorMessageHandler handler){
         map.put(ExternalChannelCodeEnum.RECRN002C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECAG003C.name(), handler);
     }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
@@ -1,10 +1,7 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
 import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
-import it.pagopa.pn.paperchannel.middleware.db.dao.AddressDAO;
-import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
-import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
-import it.pagopa.pn.paperchannel.middleware.db.dao.PaperRequestErrorDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.*;
 import it.pagopa.pn.paperchannel.middleware.msclient.ExternalChannelClient;
 import it.pagopa.pn.paperchannel.middleware.queue.consumer.MetaDematCleaner;
 import it.pagopa.pn.paperchannel.service.SqsSender;
@@ -36,29 +33,123 @@ public class HandlersFactory {
 
     private final MetaDematCleaner metaDematCleaner;
 
+    private final RequestDeliveryDAO requestDeliveryDAO;
+
     private ConcurrentHashMap<String, MessageHandler> map;
 
 
-    private final LogMessageHandler logExtChannelsMessageHandler = new LogMessageHandler();
+    private final LogMessageHandler logExtChannelsMessageHandler = LogMessageHandler.builder().build();
 
     @PostConstruct
     public void initializeHandlers() {
-        var saveMetadataMessageHandler = new SaveMetadataMessageHandler(eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
-        var saveDematMessageHandler = new SaveDematMessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), pnPaperChannelConfig.isZipHandleActive());
-        var retryableErrorExtChannelsMessageHandler = new RetryableErrorMessageHandler(sqsSender, externalChannelClient, addressDAO, paperRequestErrorDAO, pnPaperChannelConfig);
-        var notRetryableErrorMessageHandler = new NotRetryableErrorMessageHandler(sqsSender, paperRequestErrorDAO);
-        var notRetriableWithoutSendErrorMessageHandler = new NotRetriableWithoutSendErrorMessageHandler(paperRequestErrorDAO);
-        var customAggregatorMessageHandler = new CustomAggregatorMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
-        var aggregatorMessageHandler = new AggregatorMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
-        var directlySendMessageHandler = new DirectlySendMessageHandler(sqsSender);
-        var pnag012MessageHandler = new PNAG012MessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta(), pnPaperChannelConfig.getRequiredDemats(), pnPaperChannelConfig.isZipHandleActive());
-        var recag012MessageHandler = new RECAG012MessageHandler(eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta(), pnag012MessageHandler);
-        var recag011AMessageHandler =  new RECAG011AMessageHandler(sqsSender, eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
-        var recag011BMessageHandler = new RECAG011BMessageHandler(sqsSender, eventDematDAO, pnPaperChannelConfig.getTtlExecutionDaysDemat(), pnag012MessageHandler, pnPaperChannelConfig.isZipHandleActive());
-        var recag008CMessageHandler = new RECAG008CMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner);
-        var complex890MessageHandler = new Complex890MessageHandler(sqsSender, eventMetaDAO, metaDematCleaner, pnPaperChannelConfig.getRefinementDuration() );
-        var recrn00xcMessageHandler = new RECRN00XCMessageHandler(sqsSender, eventMetaDAO, metaDematCleaner, pnPaperChannelConfig.getRefinementDuration());
-        var recrn011cMessageHandler = new RECRN011MessageHandler(sqsSender, eventMetaDAO, pnPaperChannelConfig.getTtlExecutionDaysMeta());
+        
+        MessageHandler saveMetadataMessageHandler = SaveMetadataMessageHandler.builder()
+                .eventMetaDAO(eventMetaDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+        
+        MessageHandler saveDematMessageHandler = SaveDematMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventDematDAO(eventDematDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+        
+        MessageHandler retryableErrorExtChannelsMessageHandler = RetryableErrorMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .externalChannelClient(externalChannelClient)
+                .addressDAO(addressDAO)
+                .paperRequestErrorDAO(paperRequestErrorDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+        
+        MessageHandler notRetryableErrorMessageHandler = NotRetryableErrorMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .paperRequestErrorDAO(paperRequestErrorDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .build();
+        
+        MessageHandler notRetriableWithoutSendErrorMessageHandler = NotRetriableWithoutSendErrorMessageHandler.builder()
+                .paperRequestErrorDAO(paperRequestErrorDAO)
+                .build();
+        
+        MessageHandler customAggregatorMessageHandler = CustomAggregatorMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .metaDematCleaner(metaDematCleaner)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .build();
+        
+        MessageHandler aggregatorMessageHandler = AggregatorMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .metaDematCleaner(metaDematCleaner)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .build();
+         
+        MessageHandler directlySendMessageHandler = DirectlySendMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .build();
+         
+        PNAG012MessageHandler pnag012MessageHandler = PNAG012MessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventDematDAO(eventDematDAO)
+                .eventMetaDAO(eventMetaDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+         
+        MessageHandler recag012MessageHandler = RECAG012MessageHandler.builder()
+                .eventMetaDAO(eventMetaDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .pnag012MessageHandler(pnag012MessageHandler)
+                .build();
+        
+        MessageHandler recag011AMessageHandler = RECAG011AMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+        
+        MessageHandler recag011BMessageHandler = RECAG011BMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventDematDAO(eventDematDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .pnag012MessageHandler(pnag012MessageHandler)
+                .build();
+        
+        MessageHandler recag008CMessageHandler = RECAG008CMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .metaDematCleaner(metaDematCleaner)
+                .build();
+        
+        MessageHandler complex890MessageHandler = Complex890MessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .metaDematCleaner(metaDematCleaner)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+
+        MessageHandler recrn00xcMessageHandler = RECRN00XCMessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .metaDematCleaner(metaDematCleaner)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+
+        MessageHandler recrn011cMessageHandler = RECRN011MessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .pnPaperChannelConfig(pnPaperChannelConfig)
+                .build();
+
 
         map = new ConcurrentHashMap<>();
 
@@ -89,7 +180,7 @@ public class HandlersFactory {
         map.put("PNAG012", pnag012MessageHandler);
     }
 
-    private void addRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, RetryableErrorMessageHandler handler) {
+    private void addRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
         map.put(ExternalChannelCodeEnum.RECRS006.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRN006.name(), handler);
         map.put(ExternalChannelCodeEnum.RECAG004.name(), handler);
@@ -100,7 +191,7 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECAG013.name(), handler);
     }
 
-    private void addNotRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, NotRetryableErrorMessageHandler handler) {
+    private void addNotRetryableErrorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
         map.put(ExternalChannelCodeEnum.CON998.name(), handler);
         map.put(ExternalChannelCodeEnum.CON997.name(), handler);
         map.put(ExternalChannelCodeEnum.CON996.name(), handler);
@@ -108,11 +199,11 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.CON993.name(), handler);
     }
 
-    private void addNotRetryableErrorStatusCodeWithoutSend(ConcurrentHashMap<String, MessageHandler> map, NotRetriableWithoutSendErrorMessageHandler handler){
+    private void addNotRetryableErrorStatusCodeWithoutSend(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler){
         map.put(ExternalChannelCodeEnum.P010.name(), handler);
     }
 
-    private void addSaveMetadataStatusCodes(ConcurrentHashMap<String, MessageHandler> map, SaveMetadataMessageHandler handler) {
+    private void addSaveMetadataStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
         map.put("RECRS002A", handler);
         map.put("RECRS002D", handler);
         map.put("RECRS004A", handler);
@@ -137,7 +228,7 @@ public class HandlersFactory {
     }
 
 
-    private void addSaveDematStatusCodes(ConcurrentHashMap<String, MessageHandler> map, SaveDematMessageHandler handler) {
+    private void addSaveDematStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
         map.put(ExternalChannelCodeEnum.RECRS002B.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS002E.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS004B.name(), handler);
@@ -163,7 +254,7 @@ public class HandlersFactory {
 
     }
 
-    private void addDirectlySendStatusCodes(ConcurrentHashMap<String, MessageHandler> map, DirectlySendMessageHandler handler) {
+    private void addDirectlySendStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
 
 
         //caso CON080, RECRI001, RECRI002
@@ -186,7 +277,7 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECRN010.name(), handler);
     }
 
-    private void addAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, AggregatorMessageHandler handler) {
+    private void addAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler) {
         map.put(ExternalChannelCodeEnum.RECRS002C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS002F.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRS004C.name(), handler);
@@ -205,7 +296,7 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECRSI004C.name(), handler);
     }
 
-    private void addCustomAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, CustomAggregatorMessageHandler handler){
+    private void addCustomAggregatorStatusCodes(ConcurrentHashMap<String, MessageHandler> map, MessageHandler handler){
         map.put(ExternalChannelCodeEnum.RECRN002C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECAG003C.name(), handler);
     }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/LogMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/LogMessageHandler.java
@@ -2,13 +2,14 @@ package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 // handler solo log
 @Slf4j
+@Builder
 public class LogMessageHandler implements MessageHandler {
-
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetriableWithoutSendErrorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetriableWithoutSendErrorMessageHandler.java
@@ -5,8 +5,10 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.PaperRequestErrorDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.utils.PnLogAudit;
+import lombok.Builder;
 import reactor.core.publisher.Mono;
 
+@Builder
 public class NotRetriableWithoutSendErrorMessageHandler implements MessageHandler {
 
     private static final String FINISH_RETRY_EXTERNAL_CHANNEL_MESSAGE = "requestId = %s finish retry to External Channel";

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetriableWithoutSendErrorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetriableWithoutSendErrorMessageHandler.java
@@ -15,10 +15,6 @@ public class NotRetriableWithoutSendErrorMessageHandler implements MessageHandle
 
     private final PaperRequestErrorDAO paperRequestErrorDAO;
 
-    public NotRetriableWithoutSendErrorMessageHandler(PaperRequestErrorDAO paperRequestErrorDAO) {
-        this.paperRequestErrorDAO = paperRequestErrorDAO;
-    }
-
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {
         PnLogAudit pnLogAudit = new PnLogAudit();

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandler.java
@@ -6,18 +6,15 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.service.SqsSender;
 import it.pagopa.pn.paperchannel.utils.PnLogAudit;
+import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Mono;
 
+@SuperBuilder
 public class NotRetryableErrorMessageHandler extends SendToDeliveryPushHandler {
 
     private static final String FINISH_RETRY_EXTERNAL_CHANNEL_MESSAGE = "requestId = %s finish retry to External Channel";
 
     private final PaperRequestErrorDAO paperRequestErrorDAO;
-
-    public NotRetryableErrorMessageHandler(SqsSender sqsSender, PaperRequestErrorDAO paperRequestErrorDAO) {
-        super(sqsSender);
-        this.paperRequestErrorDAO = paperRequestErrorDAO;
-    }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG008CMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG008CMessageHandler.java
@@ -6,7 +6,7 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 import it.pagopa.pn.paperchannel.middleware.queue.consumer.MetaDematCleaner;
-import it.pagopa.pn.paperchannel.service.SqsSender;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -17,6 +17,7 @@ import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.WRONG_EVENT_
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 
 @Slf4j
+@SuperBuilder
 public class RECAG008CMessageHandler extends SendToDeliveryPushHandler {
 
     static final String META_RECAG012_STATUS_CODE = buildMetaStatusCode(RECAG012_STATUS_CODE);
@@ -24,12 +25,6 @@ public class RECAG008CMessageHandler extends SendToDeliveryPushHandler {
 
     private final EventMetaDAO eventMetaDAO;
     private final MetaDematCleaner metaDematCleaner;
-
-    public RECAG008CMessageHandler(SqsSender sqsSender, EventMetaDAO eventMetaDAO, MetaDematCleaner metaDematCleaner) {
-        super(sqsSender);
-        this.eventMetaDAO = eventMetaDAO;
-        this.metaDematCleaner = metaDematCleaner;
-    }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011AMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011AMessageHandler.java
@@ -6,18 +6,15 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
 import it.pagopa.pn.paperchannel.service.SqsSender;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @Slf4j
+@SuperBuilder
 public class RECAG011AMessageHandler extends SaveMetadataMessageHandler {
 
     private final SqsSender sqsSender;
-
-    public RECAG011AMessageHandler(SqsSender sqsSender, EventMetaDAO eventMetaDAO, Long ttlDaysMeta) {
-        super(eventMetaDAO, ttlDaysMeta);
-        this.sqsSender = sqsSender;
-    }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandler.java
@@ -1,9 +1,8 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
-import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
-import it.pagopa.pn.paperchannel.service.SqsSender;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -11,14 +10,10 @@ import reactor.core.publisher.Mono;
 // 2. invocare l'handler di PNAG012
 
 @Slf4j
+@SuperBuilder
 public class RECAG011BMessageHandler extends SaveDematMessageHandler {
 
     private final PNAG012MessageHandler pnag012MessageHandler;
-
-    public RECAG011BMessageHandler(SqsSender sqsSender, EventDematDAO eventDematDAO, Long ttlDaysDemat, PNAG012MessageHandler pnag012MessageHandler, boolean zipHandleActive) {
-        super(sqsSender, eventDematDAO, ttlDaysDemat, zipHandleActive);
-        this.pnag012MessageHandler = pnag012MessageHandler;
-    }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
@@ -6,6 +6,7 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -20,14 +21,10 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 // Poi, esegue il flusso PNAG012, al netto del superamento delle varie condizioni che si trovano nell'handler del PNAG012.
 // L'aggiunta della gestion del PNAG012 è stata fatta a seguito del task PN-8911.
 @Slf4j
+@SuperBuilder
 public class RECAG012MessageHandler extends SaveMetadataMessageHandler {
 
     private final PNAG012MessageHandler pnag012MessageHandler;
-
-    public RECAG012MessageHandler(EventMetaDAO eventMetaDAO, Long ttlDays, PNAG012MessageHandler pnag012MessageHandler) {
-        super(eventMetaDAO, ttlDays);
-        this.pnag012MessageHandler = pnag012MessageHandler;
-    }
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandler.java
@@ -2,10 +2,8 @@ package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
 import it.pagopa.pn.paperchannel.exception.PnGenericException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
-import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
-
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -13,7 +11,8 @@ import reactor.core.publisher.Mono;
 import java.util.Optional;
 
 import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.WRONG_RECAG012_DATA;
-import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaRequestId;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaStatusCode;
 
 // Il RECAG012 è considerato come entità logica un metadata
 // Viene cercato sulla tabella META se esiste già l'evento, se non esiste in tabella, viene salvato a DB,

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN011MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN011MessageHandler.java
@@ -7,20 +7,15 @@ import it.pagopa.pn.paperchannel.mapper.SendEventMapper;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.service.SqsSender;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @Slf4j
+@SuperBuilder
 public class RECRN011MessageHandler extends SaveMetadataMessageHandler {
 
     private final SqsSender sqsSender;
-
-
-    public RECRN011MessageHandler(SqsSender sqsSender, EventMetaDAO eventMetaDAO, Long ttlDays) {
-        super(eventMetaDAO, ttlDays);
-        this.sqsSender = sqsSender;
-    }
-
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN011MessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN011MessageHandler.java
@@ -4,7 +4,6 @@ import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.mapper.SendEventMapper;
-import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.service.SqsSender;
 import lombok.experimental.SuperBuilder;

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandler.java
@@ -14,9 +14,9 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.middleware.msclient.ExternalChannelClient;
 import it.pagopa.pn.paperchannel.middleware.queue.model.EventTypeEnum;
 import it.pagopa.pn.paperchannel.model.AttachmentInfo;
-import it.pagopa.pn.paperchannel.service.SqsSender;
 import it.pagopa.pn.paperchannel.utils.Const;
 import it.pagopa.pn.paperchannel.utils.PnLogAudit;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import reactor.core.publisher.Mono;
@@ -27,29 +27,15 @@ import static it.pagopa.pn.paperchannel.exception.ExceptionTypeEnum.EXTERNAL_CHA
 
 // handler per stati gialli: Retry su ExtCh con suffisso +1, invio dello stato in progress verso DP
 @Slf4j
-//@RequiredArgsConstructor
+@SuperBuilder
 public class RetryableErrorMessageHandler extends SendToDeliveryPushHandler {
 
     private static final String REQUEST_TO_EXTERNAL_CHANNEL = "prepare requestId = %s, trace_id = %s  request to External Channel";
 
     private final ExternalChannelClient externalChannelClient;
-
     private final AddressDAO addressDAO;
-
     private final PaperRequestErrorDAO paperRequestErrorDAO;
-
     private final PnPaperChannelConfig pnPaperChannelConfig;
-
-    public RetryableErrorMessageHandler(SqsSender sqsSender, ExternalChannelClient externalChannelClient,
-                                        AddressDAO addressDAO, PaperRequestErrorDAO paperRequestErrorDAO,
-                                        PnPaperChannelConfig pnPaperChannelConfig) {
-        super(sqsSender);
-        this.externalChannelClient = externalChannelClient;
-        this.addressDAO = addressDAO;
-        this.paperRequestErrorDAO = paperRequestErrorDAO;
-        this.pnPaperChannelConfig = pnPaperChannelConfig;
-    }
-
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveDematMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveDematMessageHandler.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.exception.PnDematNotValidException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.AttachmentDetailsDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
@@ -7,8 +8,8 @@ import it.pagopa.pn.paperchannel.mapper.DematInternalEventMapper;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
-import it.pagopa.pn.paperchannel.service.SqsSender;
 import it.pagopa.pn.paperchannel.utils.Utility;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
@@ -17,14 +18,15 @@ import reactor.core.publisher.Mono;
 import java.util.ArrayList;
 import java.util.List;
 
-import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildDematRequestId;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildDocumentTypeStatusCode;
 
 //Tutti gli eventi, fatta eccezione di quelli evidenziati (*), dovranno essere memorizzati nella tabella come entità DEMAT.
 // Tutti gli eventi che contengono dematerializzazioni del tipo (Plico, 23L, Indagine, AR) dovranno essere inviati come
 // eventi PROGRESS verso delivery-push (oltre che salvati a db)
 @Slf4j
+@SuperBuilder
 public class SaveDematMessageHandler extends SendToDeliveryPushHandler {
-
 
     private static final List<String> ATTACHMENT_TYPES_SEND_TO_DELIVERY_PUSH = List.of(
             "Plico",
@@ -34,18 +36,7 @@ public class SaveDematMessageHandler extends SendToDeliveryPushHandler {
     );
 
     protected final EventDematDAO eventDematDAO;
-
-    private final Long ttlDays;
-
-    private final boolean zipHandleActive;
-
-    public SaveDematMessageHandler(SqsSender sqsSender, EventDematDAO eventDematDAO, Long ttlDays, boolean zipHandleActive) {
-        super(sqsSender);
-        this.eventDematDAO = eventDematDAO;
-        this.ttlDays = ttlDays;
-        this.zipHandleActive = zipHandleActive;
-    }
-
+    protected final PnPaperChannelConfig pnPaperChannelConfig;
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {
@@ -95,7 +86,7 @@ public class SaveDematMessageHandler extends SendToDeliveryPushHandler {
         PnEventDemat pnEventDemat = new PnEventDemat();
         pnEventDemat.setDematRequestId(buildDematRequestId(paperRequest.getRequestId()));
         pnEventDemat.setDocumentTypeStatusCode(buildDocumentTypeStatusCode(attachmentDetailsDto.getDocumentType(), paperRequest.getStatusCode()));
-        pnEventDemat.setTtl(paperRequest.getStatusDateTime().plusDays(ttlDays).toEpochSecond());
+        pnEventDemat.setTtl(paperRequest.getStatusDateTime().plusDays(pnPaperChannelConfig.getTtlExecutionDaysDemat()).toEpochSecond());
 
         pnEventDemat.setRequestId(paperRequest.getRequestId());
         pnEventDemat.setStatusCode(paperRequest.getStatusCode());
@@ -116,7 +107,7 @@ public class SaveDematMessageHandler extends SendToDeliveryPushHandler {
     }
 
     private boolean isZipHandleFlow(String requestId, AttachmentDetailsDto attachmentDetailsDto) {
-        return zipHandleActive &&
+        return pnPaperChannelConfig.isZipHandleActive() &&
                 Utility.isNotCallCenterEvoluto(requestId) &&
                 isAZipFile(attachmentDetailsDto) &&
                 isAttachmentMappedAsProgress(attachmentDetailsDto.getDocumentType());

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveMetadataMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveMetadataMessageHandler.java
@@ -8,12 +8,12 @@ import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDiscoveredAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
-import lombok.RequiredArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
-import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaRequestId;
+import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaStatusCode;
 
 // handler salva metadati (vedere Gestione eventi di pre-esito)
 @Slf4j

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveMetadataMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveMetadataMessageHandler.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.DiscoveredAddressDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.mapper.common.BaseMapperImpl;
@@ -8,20 +9,19 @@ import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDiscoveredAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
 
 // handler salva metadati (vedere Gestione eventi di pre-esito)
-@RequiredArgsConstructor
 @Slf4j
+@SuperBuilder
 public class SaveMetadataMessageHandler implements MessageHandler {
 
     protected final EventMetaDAO eventMetaDAO;
-
-    private final Long ttlDays;
-
+    protected final PnPaperChannelConfig pnPaperChannelConfig;
 
     @Override
     public Mono<Void> handleMessage(PnDeliveryRequest entity, PaperProgressStatusEventDto paperRequest) {
@@ -36,7 +36,7 @@ public class SaveMetadataMessageHandler implements MessageHandler {
         PnEventMeta pnEventMeta = new PnEventMeta();
         pnEventMeta.setMetaRequestId(buildMetaRequestId(paperRequest.getRequestId()));
         pnEventMeta.setMetaStatusCode(buildMetaStatusCode(paperRequest.getStatusCode()));
-        pnEventMeta.setTtl(paperRequest.getStatusDateTime().plusDays(ttlDays).toEpochSecond());
+        pnEventMeta.setTtl(paperRequest.getStatusDateTime().plusDays(pnPaperChannelConfig.getTtlExecutionDaysMeta()).toEpochSecond());
 
         pnEventMeta.setRequestId(paperRequest.getRequestId());
         pnEventMeta.setStatusCode(paperRequest.getStatusCode());

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/AggregatorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/AggregatorMessageHandlerTest.java
@@ -98,6 +98,9 @@ class AggregatorMessageHandlerTest {
         verify(mockMetaDao, timeout(2000).times(1)).deleteBatch(any(String.class), any(String.class));
         // deleteEventDemat call
         verify(mockDematDao, timeout(2000).times(1)).deleteBatch(any(String.class), any(String.class));
+
+        verify(requestDeliveryDAO, timeout(2000).times(1)).updateData(entity);
+
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(1)).pushSendEvent(caturedSendEvent.capture());
 
@@ -136,16 +139,17 @@ class AggregatorMessageHandlerTest {
         // deleteEventMeta
         when(mockMetaDao.deleteEventMeta(any(String.class), any(String.class))).thenReturn(Mono.empty());
 
-        when(requestDeliveryDAO.updateData(any(PnDeliveryRequest.class))).thenReturn(Mono.just(entity));
-
         // assertDoNotThrow with call
         assertThrows(PnGenericException.class, () -> handler.handleMessage(entity, paperRequest).block());
 
         // check invocations: verify
         // getDeliveryEventMeta call
         verify(mockMetaDao, timeout(2000).times(1)).getDeliveryEventMeta(any(String.class), any(String.class));
+
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(0)).pushSendEvent(any());
+
+        verify(requestDeliveryDAO, never()).updateData(entity);
     }
 
     @Test
@@ -196,6 +200,8 @@ class AggregatorMessageHandlerTest {
         verify(mockMetaDao, timeout(2000).times(0)).deleteBatch(any(String.class), any(String.class));
         // deleteEventDemat call
         verify(mockDematDao, timeout(2000).times(0)).deleteBatch(any(String.class), any(String.class));
+
+        verify(requestDeliveryDAO, timeout(2000).times(1)).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -243,6 +249,8 @@ class AggregatorMessageHandlerTest {
         verify(mockDematDao, timeout(2000).times(1)).deleteBatch(any(String.class), any(String.class));
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(1)).pushSendEvent(any(SendEvent.class));
+
+        verify(requestDeliveryDAO, timeout(2000).times(1)).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -290,6 +298,8 @@ class AggregatorMessageHandlerTest {
         verify(mockDematDao, timeout(2000).times(1)).deleteBatch(any(String.class), any(String.class));
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(1)).pushSendEvent(any(SendEvent.class));
+
+        verify(requestDeliveryDAO, timeout(2000).times(1)).updateData(any(PnDeliveryRequest.class));
     }
 
     private PnEventMeta createPnEventMeta() {

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/Complex890MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/Complex890MessageHandlerTest.java
@@ -1,11 +1,13 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.exception.PnGenericException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.mapper.SendEventMapper;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.RequestDeliveryDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventMeta;
 import it.pagopa.pn.paperchannel.middleware.queue.consumer.MetaDematCleaner;
@@ -28,30 +30,38 @@ import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaRequestId;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.buildMetaStatusCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 class Complex890MessageHandlerTest {
 
-    private SqsSender sqsSender;
-
-    private EventMetaDAO eventMetaDAO;
-
-    private MetaDematCleaner metaDematCleaner;
-
     private Complex890MessageHandler handler;
 
-    private int DAYS_REFINEMENT = 10;
+    private SqsSender sqsSender;
+    private EventMetaDAO eventMetaDAO;
+    private RequestDeliveryDAO requestDeliveryDAO;
+
+    private final int DAYS_REFINEMENT = 10;
 
     @BeforeEach
     public void init() {
         sqsSender = mock(SqsSender.class);
         eventMetaDAO = mock(EventMetaDAO.class);
-        metaDematCleaner = mock(MetaDematCleaner.class);
+        requestDeliveryDAO = mock(RequestDeliveryDAO.class);
+
+        MetaDematCleaner metaDematCleaner = mock(MetaDematCleaner.class);
+
+        PnPaperChannelConfig mockConfig = new PnPaperChannelConfig();
+        mockConfig.setRefinementDuration(Duration.of(DAYS_REFINEMENT, ChronoUnit.DAYS));
 
         when(metaDematCleaner.clean(anyString())).thenReturn(Mono.empty());
 
-        handler = new Complex890MessageHandler(sqsSender, eventMetaDAO, metaDematCleaner, Duration.of(DAYS_REFINEMENT, ChronoUnit.DAYS));
+        handler = Complex890MessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .metaDematCleaner(metaDematCleaner)
+                .pnPaperChannelConfig(mockConfig)
+                .build();
     }
 
     //CASO 1.ii
@@ -160,6 +170,7 @@ class Complex890MessageHandlerTest {
         pnEventMetaRECAG005A.setStatusDateTime(Instant.parse("2023-03-16T17:07:00.000Z"));
 
         when(eventMetaDAO.findAllByRequestId(metadataRequestid)).thenReturn(Flux.just(pnEventMetaRECAG012, pnEventMetaRECAG011A, pnEventMetaRECAG005A));
+        when(requestDeliveryDAO.updateData(any(PnDeliveryRequest.class))).thenReturn(Mono.just(entity));
 
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 
@@ -206,6 +217,7 @@ class Complex890MessageHandlerTest {
         pnEventMetaRECAG005A.setStatusDateTime(Instant.parse("2023-03-16T17:07:00.000Z"));
 
         when(eventMetaDAO.findAllByRequestId(metadataRequestid)).thenReturn(Flux.just(pnEventMetaRECAG012, pnEventMetaRECAG011A, pnEventMetaRECAG005A));
+        when(requestDeliveryDAO.updateData(any(PnDeliveryRequest.class))).thenReturn(Mono.just(entity));
 
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/CustomAggregatorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/CustomAggregatorMessageHandlerTest.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -103,6 +104,12 @@ class CustomAggregatorMessageHandlerTest {
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(1)).pushSendEvent(caturedSendEvent.capture());
 
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
+
         // arricchimento
         assertEquals("failureCause1", caturedSendEvent.getValue().getDeliveryFailureCause());
         assertNotNull(caturedSendEvent.getValue().getDiscoveredAddress());
@@ -145,6 +152,8 @@ class CustomAggregatorMessageHandlerTest {
         verify(mockMetaDao, timeout(2000).times(1)).getDeliveryEventMeta(any(String.class), any(String.class));
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(0)).pushSendEvent(any());
+
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -195,6 +204,12 @@ class CustomAggregatorMessageHandlerTest {
         verify(mockMetaDao, timeout(2000).times(0)).deleteBatch(any(String.class), any(String.class));
         // deleteEventDemat call
         verify(mockDematDao, timeout(2000).times(0)).deleteBatch(any(String.class), any(String.class));
+
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactoryTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactoryTest.java
@@ -19,7 +19,7 @@ class HandlersFactoryTest {
     @BeforeEach
     public void init() {
         PnPaperChannelConfig mockConfig = mock(PnPaperChannelConfig.class);
-        handlersFactory = new HandlersFactory(null, null, null, mockConfig, null, null, null, null);
+        handlersFactory = new HandlersFactory(null, null, null, mockConfig, null, null, null, null, null);
         handlersFactory.initializeHandlers();
     }
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/LogMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/LogMessageHandlerTest.java
@@ -15,7 +15,7 @@ class LogMessageHandlerTest {
 
     @BeforeEach
     public void init() {
-        handler = new LogMessageHandler();
+        handler = LogMessageHandler.builder().build();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandlerTest.java
@@ -75,5 +75,7 @@ class NotRetryableErrorMessageHandlerTest {
                     requestError.getError().equals(entity.getStatusCode()) &&
                     requestError.getFlowThrow().equals(entity.getStatusDetail())
                 ));
+
+        verify(requestDeliveryDAO, never()).updateData(entity);
     }
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableErrorMessageHandlerTest.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.middleware.db.dao.PaperRequestErrorDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.RequestDeliveryDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
 import it.pagopa.pn.paperchannel.service.SqsSender;
@@ -22,12 +23,19 @@ class NotRetryableErrorMessageHandlerTest {
 
     private PaperRequestErrorDAO paperRequestErrorDAOMock;
     private SqsSender mockSqsSender;
+    private RequestDeliveryDAO requestDeliveryDAO;
 
     @BeforeEach
     public void init() {
         mockSqsSender = mock(SqsSender.class);
         paperRequestErrorDAOMock = mock(PaperRequestErrorDAO.class);
-        handler = new NotRetryableErrorMessageHandler(mockSqsSender, paperRequestErrorDAOMock);
+        requestDeliveryDAO = mock(RequestDeliveryDAO.class);
+
+        handler = NotRetryableErrorMessageHandler.builder()
+                .sqsSender(mockSqsSender)
+                .paperRequestErrorDAO(paperRequestErrorDAOMock)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .build();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableWithoutSendErrorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/NotRetryableWithoutSendErrorMessageHandlerTest.java
@@ -24,7 +24,9 @@ class NotRetryableWithoutSendErrorMessageHandlerTest {
     @BeforeEach
     public void init() {
         paperRequestErrorDAOMock = mock(PaperRequestErrorDAO.class);
-        handler = new NotRetriableWithoutSendErrorMessageHandler(paperRequestErrorDAOMock);
+        handler = NotRetriableWithoutSendErrorMessageHandler.builder()
+                .paperRequestErrorDAO(paperRequestErrorDAOMock)
+                .build();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/PNAG012MessageHandlerTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import static it.pagopa.pn.paperchannel.middleware.queue.consumer.handler.PNAG012MessageHandler.*;
 import static it.pagopa.pn.paperchannel.utils.MetaDematUtils.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.*;
 
@@ -123,6 +124,11 @@ class PNAG012MessageHandlerTest {
         verify(eventMetaDAO, times(1)).putIfAbsent(any(PnEventMeta.class));
         verify(mockSqsSender, times(1)).pushSendEvent(any(SendEvent.class));
 
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
     @Test
@@ -178,6 +184,11 @@ class PNAG012MessageHandlerTest {
         verify(eventMetaDAO, times(1)).putIfAbsent(any(PnEventMeta.class));
         verify(mockSqsSender, times(1)).pushSendEvent(any(SendEvent.class));
 
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
     @Test
@@ -246,6 +257,12 @@ class PNAG012MessageHandlerTest {
         verify(eventMetaDAO, times(1)).getDeliveryEventMeta(anyString(), anyString());
         verify(eventMetaDAO, times(1)).putIfAbsent(any(PnEventMeta.class));
         verify(mockSqsSender, times(1)).pushSendEvent(any(SendEvent.class));
+
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
     @Test
@@ -294,6 +311,7 @@ class PNAG012MessageHandlerTest {
         //mi aspetto che il flusso venga bloccato e quindi on invii l'evento a delivery-push
         verify(mockSqsSender, never()).pushSendEvent(any());
 
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -345,6 +363,7 @@ class PNAG012MessageHandlerTest {
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
         verify(mockSqsSender, never()).pushSendEvent(any());
 
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -385,6 +404,7 @@ class PNAG012MessageHandlerTest {
         verify(eventMetaDAO, never()).getDeliveryEventMeta(anyString(), anyString());
         verify(eventMetaDAO, never()).putIfAbsent(any(PnEventMeta.class));
         verify(mockSqsSender, never()).pushSendEvent(any(SendEvent.class));
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -439,6 +459,12 @@ class PNAG012MessageHandlerTest {
         // Then
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
         verify(mockSqsSender, times(1)).pushSendEvent(any());
+
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
     @Test
@@ -498,6 +524,12 @@ class PNAG012MessageHandlerTest {
         // Then
         assertDoesNotThrow(() -> handler.handleMessage(entity, paperRequest).block());
         verify(mockSqsSender, times(1)).pushSendEvent(any());
+
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
     @Test
@@ -539,6 +571,7 @@ class PNAG012MessageHandlerTest {
         verify(eventMetaDAO, never()).getDeliveryEventMeta(any(), any());
         verify(mockSqsSender, never()).pushSendEvent(any());
 
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     private PnEventMeta buildPnEventMeta(PaperProgressStatusEventDto paperRequest) {

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG008CMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG008CMessageHandlerTest.java
@@ -5,6 +5,7 @@ import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.RequestDeliveryDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDiscoveredAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
@@ -28,19 +29,27 @@ import static org.mockito.Mockito.*;
 
 class RECAG008CMessageHandlerTest {
     private RECAG008CMessageHandler handler;
+
     private SqsSender mockSqsSender;
     private EventDematDAO mockDematDao;
     private EventMetaDAO mockMetaDao;
+    private RequestDeliveryDAO requestDeliveryDAO;
 
     @BeforeEach
     public void init() {
         mockSqsSender = mock(SqsSender.class);
         mockMetaDao = mock(EventMetaDAO.class);
         mockDematDao = mock(EventDematDAO.class);
+        requestDeliveryDAO = mock(RequestDeliveryDAO.class);
 
         MetaDematCleaner metaDematCleaner = new MetaDematCleaner(mockDematDao, mockMetaDao);
 
-        handler = new RECAG008CMessageHandler(mockSqsSender, mockMetaDao, metaDematCleaner);
+        handler = RECAG008CMessageHandler.builder()
+                .sqsSender(mockSqsSender)
+                .eventMetaDAO(mockMetaDao)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .metaDematCleaner(metaDematCleaner)
+                .build();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG008CMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG008CMessageHandlerTest.java
@@ -99,6 +99,8 @@ class RECAG008CMessageHandlerTest {
         verify(mockDematDao, timeout(2000).times(1)).deleteBatch(any(String.class), any(String.class));
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(1)).pushSendEvent(any(SendEvent.class));
+
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -150,6 +152,8 @@ class RECAG008CMessageHandlerTest {
         verify(mockDematDao, timeout(2000).times(0)).deleteBatch(any(String.class), any(String.class));
         // DeliveryPush send via SQS verification
         verify(mockSqsSender, timeout(2000).times(1)).pushSendEvent(any(SendEvent.class));
+
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     private PnEventMeta createPnEventMeta() {

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011AMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011AMessageHandlerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
@@ -34,7 +35,14 @@ class RECAG011AMessageHandlerTest {
 
         long ttlDays = 365;
 
-        handler = new RECAG011AMessageHandler(mockSqsSender, mockDao, ttlDays);
+        PnPaperChannelConfig mockConfig = new PnPaperChannelConfig();
+        mockConfig.setTtlExecutionDaysMeta(ttlDays);
+
+        handler = RECAG011AMessageHandler.builder()
+                .sqsSender(mockSqsSender)
+                .eventMetaDAO(mockDao)
+                .pnPaperChannelConfig(mockConfig)
+                .build();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG011BMessageHandlerTest.java
@@ -152,7 +152,11 @@ class RECAG011BMessageHandlerTest {
         sendPNAG012Event.setClientRequestTimeStamp(sendEventArgumentCaptor.getAllValues().get(1).getClientRequestTimeStamp());
         assertThat(sendEventArgumentCaptor.getAllValues().get(1)).isEqualTo(sendPNAG012Event);
 
-
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
     @Test
@@ -213,7 +217,7 @@ class RECAG011BMessageHandlerTest {
         //mi aspetto che NON mandi il messaggio PNAG012 a delivery-push
         verify(mockSqsSender, times(0)).pushSendEvent(sendPNAG012Event);
 
-
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -279,7 +283,7 @@ class RECAG011BMessageHandlerTest {
         //mi aspetto che NON mandi il messaggio PNAG012 a delivery-push
         verify(mockSqsSender, times(0)).pushSendEvent(sendPNAG012Event);
 
-
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -343,7 +347,7 @@ class RECAG011BMessageHandlerTest {
         verify(mockSqsSender, times(1)).pushSendEvent(sendEventArgumentCaptor.capture());
         assertThat(sendEventArgumentCaptor.getAllValues().get(0).getStatusDetail()).isEqualTo("RECAG011B");
 
-
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECAG012MessageHandlerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
@@ -16,19 +17,26 @@ import static org.mockito.Mockito.*;
 
 class RECAG012MessageHandlerTest {
 
-    private EventMetaDAO mockDao;
-
     private PNAG012MessageHandler mockPnag012MessageHandler;
-
     private SaveMetadataMessageHandler handler;
 
+    private EventMetaDAO mockDao;
 
     @BeforeEach
     public void init() {
+        long ttlDays = 365;
+
         mockDao = mock(EventMetaDAO.class);
         mockPnag012MessageHandler = mock(PNAG012MessageHandler.class);
-        long ttlDays = 365;
-        handler = new RECAG012MessageHandler(mockDao, ttlDays, mockPnag012MessageHandler);
+
+        PnPaperChannelConfig mockConfig = new PnPaperChannelConfig();
+        mockConfig.setTtlExecutionDaysMeta(ttlDays);
+
+        handler = RECAG012MessageHandler.builder()
+                .eventMetaDAO(mockDao)
+                .pnPaperChannelConfig(mockConfig)
+                .pnag012MessageHandler(mockPnag012MessageHandler)
+                .build();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN00XCMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN00XCMessageHandlerTest.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
@@ -99,6 +100,12 @@ class RECRN00XCMessageHandlerTest {
 
         Mono<Void> mono = this.handler.handleMessage(entity, paperRequest);
         Assertions.assertDoesNotThrow(() -> mono.block());
+
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
 
@@ -141,6 +148,8 @@ class RECRN00XCMessageHandlerTest {
         SendEvent sendEvent = caturedSendEvent.getValue();
         Assertions.assertEquals(StatusCodeEnum.PROGRESS, sendEvent.getStatusCode());
         Assertions.assertEquals(statusRECRN003C, sendEvent.getStatusDetail());
+
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
 
@@ -187,6 +196,12 @@ class RECRN00XCMessageHandlerTest {
         assertEquals(StatusCodeEnum.OK, caturedSendEvent.getAllValues().get(0).getStatusCode());
         assertEquals("RECRN003C", caturedSendEvent.getAllValues().get(1).getStatusDetail());
         assertEquals(StatusCodeEnum.PROGRESS, caturedSendEvent.getAllValues().get(1).getStatusCode());
+
+        verify(requestDeliveryDAO, times(1)).updateData(argThat(pnDeliveryRequest -> {
+            assertThat(pnDeliveryRequest).isNotNull();
+            assertThat(pnDeliveryRequest.getRefined()).isTrue();
+            return true;
+        }));
     }
 
     private PnEventMeta getEventMeta(String statusCode, Instant time){

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN011MessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RECRN011MessageHandlerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
@@ -32,7 +33,14 @@ class RECRN011MessageHandlerTest {
         this.sqsSender = mock(SqsSender.class);
         this.eventMetaDAO = mock(EventMetaDAO.class);
 
-        this.messageHandler = new RECRN011MessageHandler(sqsSender, eventMetaDAO, 14L);
+        PnPaperChannelConfig mockConfig = new PnPaperChannelConfig();
+        mockConfig.setTtlExecutionDaysMeta(14L);
+
+        this.messageHandler = RECRN011MessageHandler.builder()
+                .sqsSender(sqsSender)
+                .eventMetaDAO(eventMetaDAO)
+                .pnPaperChannelConfig(mockConfig)
+                .build();
     }
 
 

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandlerTest.java
@@ -93,6 +93,8 @@ class RetryableErrorMessageHandlerTest {
 
         //verifico che viene inviato l'evento a delivery-push
         verify(mockSqsSender, times(1)).pushSendEvent(argThat((SendEvent se) -> se.getRequestId().equals(currentRequestId) ));
+
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -134,6 +136,8 @@ class RetryableErrorMessageHandlerTest {
 
         //verifico che viene inviato l'evento a delivery-push
         verify(mockSqsSender, times(1)).pushSendEvent(any(SendEvent.class));
+
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
 }

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/RetryableErrorMessageHandlerTest.java
@@ -8,6 +8,7 @@ import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendRequest;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.middleware.db.dao.AddressDAO;
 import it.pagopa.pn.paperchannel.middleware.db.dao.PaperRequestErrorDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.RequestDeliveryDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnAddress;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnRequestError;
@@ -33,14 +34,11 @@ class RetryableErrorMessageHandlerTest {
     private RetryableErrorMessageHandler handler;
 
     private PnPaperChannelConfig mockConfig;
-
     private ExternalChannelClient mockExtChannel;
-
     private SqsSender mockSqsSender;
-
     private PaperRequestErrorDAO mockRequestError;
-
     private AddressDAO mockAddressDAO;
+    private RequestDeliveryDAO requestDeliveryDAO;
 
 
     @BeforeEach
@@ -49,9 +47,17 @@ class RetryableErrorMessageHandlerTest {
         mockExtChannel = mock(ExternalChannelClient.class);
         mockAddressDAO = mock(AddressDAO.class);
         mockRequestError = mock(PaperRequestErrorDAO.class);
+        requestDeliveryDAO = mock(RequestDeliveryDAO.class);
         mockConfig = mock(PnPaperChannelConfig.class);
 
-        handler = new RetryableErrorMessageHandler(mockSqsSender, mockExtChannel, mockAddressDAO, mockRequestError, mockConfig);
+        handler = RetryableErrorMessageHandler.builder()
+                .sqsSender(mockSqsSender)
+                .externalChannelClient(mockExtChannel)
+                .addressDAO(mockAddressDAO)
+                .paperRequestErrorDAO(mockRequestError)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .pnPaperChannelConfig(mockConfig)
+                .build();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveDematMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveDematMessageHandlerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.exception.PnDematNotValidException;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.AttachmentDetailsDto;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
@@ -7,6 +8,7 @@ import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.SendEvent;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.mapper.SendEventMapper;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventDematDAO;
+import it.pagopa.pn.paperchannel.middleware.db.dao.RequestDeliveryDAO;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnDeliveryRequest;
 import it.pagopa.pn.paperchannel.middleware.db.entities.PnEventDemat;
 import it.pagopa.pn.paperchannel.service.SqsSender;
@@ -25,23 +27,34 @@ import static org.mockito.Mockito.*;
 
 class SaveDematMessageHandlerTest {
 
-    private EventDematDAO mockDao;
-
-    private SqsSender mockSqsSender;
-
     private SaveDematMessageHandler handler;
+
+    private EventDematDAO mockDao;
+    private SqsSender mockSqsSender;
+    private RequestDeliveryDAO requestDeliveryDAO;
+    private PnPaperChannelConfig mockConfig;
 
 
     @BeforeEach
     public void init() {
         mockDao = mock(EventDematDAO.class);
         mockSqsSender = mock(SqsSender.class);
+        requestDeliveryDAO = mock(RequestDeliveryDAO.class);
+
+        mockConfig = new PnPaperChannelConfig();
+        mockConfig.setTtlExecutionDaysDemat(14L);
+        mockConfig.setZipHandleActive(false);
+
+        handler = SaveDematMessageHandler.builder()
+                .sqsSender(mockSqsSender)
+                .eventDematDAO(mockDao)
+                .requestDeliveryDAO(requestDeliveryDAO)
+                .pnPaperChannelConfig(mockConfig)
+                .build();
     }
 
     @Test
     void handleMessageWithDocumentTypePlicoTest() {
-        handler = new SaveDematMessageHandler(mockSqsSender, mockDao, 365L, false);
-
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -75,8 +88,6 @@ class SaveDematMessageHandlerTest {
 
     @Test
     void handleMessageWithDocumentTypeCADTest() {
-        handler = new SaveDematMessageHandler(mockSqsSender, mockDao, 365L, false);
-
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -110,8 +121,6 @@ class SaveDematMessageHandlerTest {
 
     @Test
     void handleMessageWithDocumentTypeCADAnd23LTest() {
-        handler = new SaveDematMessageHandler(mockSqsSender, mockDao, 365L, false);
-
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -159,8 +168,6 @@ class SaveDematMessageHandlerTest {
 
     @Test
     void handleMessageWithoutAttachmentsTest() {
-        handler = new SaveDematMessageHandler(mockSqsSender, mockDao, 365L, false);
-
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
                 .requestId("requestId")
@@ -181,7 +188,8 @@ class SaveDematMessageHandlerTest {
 
     @Test
     void handleMessageWithDocumentTypePlicoWithZipHandleActiveTrueTest() {
-        handler = new SaveDematMessageHandler(mockSqsSender, mockDao, 365L, true);
+
+        mockConfig.setZipHandleActive(true);
 
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()
@@ -214,7 +222,8 @@ class SaveDematMessageHandlerTest {
 
     @Test
     void handleMessageWithDocumentTypePlicoWithZipHandleActiveTrueButMessageFromCallCenterEvolutoTest() {
-        handler = new SaveDematMessageHandler(mockSqsSender, mockDao, 365L, true);
+
+        mockConfig.setZipHandleActive(true);
 
         OffsetDateTime instant = OffsetDateTime.parse("2023-03-09T14:44:00.000Z");
         PaperProgressStatusEventDto paperRequest = new PaperProgressStatusEventDto()

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveDematMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveDematMessageHandlerTest.java
@@ -84,6 +84,8 @@ class SaveDematMessageHandlerTest {
         //mi aspetto che mandi il messaggio a delivery-push
         verify(mockSqsSender, times(1)).pushSendEvent(sendEventExpected);
 
+        // not call because it is a PROGRESS event
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -117,6 +119,8 @@ class SaveDematMessageHandlerTest {
         //mi aspetto che non mandi il messaggio a delivery-push
         verify(mockSqsSender, times(0)).pushSendEvent(sendEventNotExpected);
 
+        // not call because it is a PROGRESS event
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -163,7 +167,8 @@ class SaveDematMessageHandlerTest {
         verify(mockSqsSender, times(0)).pushSendEvent(sendEventCAD);
         //mi aspetto che mandi il messaggio a delivery-push per l'evento 23L
         verify(mockSqsSender, times(1)).pushSendEvent(sendEvent23L);
-
+        // not call because it is a PROGRESS event
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -218,6 +223,8 @@ class SaveDematMessageHandlerTest {
         //mi aspetto che mandi l'evento dematInternalEvent sulla coda interna
         verify(mockSqsSender, times(1)).pushDematZipInternalEvent(any());
 
+        // not call because it is a PROGRESS event
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
     }
 
     @Test
@@ -256,8 +263,10 @@ class SaveDematMessageHandlerTest {
         //mi aspetto che mandi il messaggio in event bridge per l'evento Plico
         verify(mockSqsSender, times(1)).pushSendEventOnEventBridge(Const.PREFIX_REQUEST_ID_SERVICE_DESK, sendEventPlico);
 
-        MDC.clear();
+        // not call because it is a PROGRESS event
+        verify(requestDeliveryDAO, never()).updateData(any(PnDeliveryRequest.class));
 
+        MDC.clear();
     }
 
     private PaperProgressStatusEventDto getPaperRequestForOneAttachment(

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveMetadataMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/SaveMetadataMessageHandlerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.paperchannel.middleware.queue.consumer.handler;
 
+import it.pagopa.pn.paperchannel.config.PnPaperChannelConfig;
 import it.pagopa.pn.paperchannel.generated.openapi.msclient.pnextchannel.v1.dto.PaperProgressStatusEventDto;
 import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.StatusCodeEnum;
 import it.pagopa.pn.paperchannel.middleware.db.dao.EventMetaDAO;
@@ -25,7 +26,14 @@ class SaveMetadataMessageHandlerTest {
     public void init() {
         mockDao = mock(EventMetaDAO.class);
         long ttlDays = 365;
-        handler = new SaveMetadataMessageHandler(mockDao, ttlDays);
+
+        PnPaperChannelConfig mockConfig = new PnPaperChannelConfig();
+        mockConfig.setTtlExecutionDaysMeta(ttlDays);
+
+        handler = SaveMetadataMessageHandler.builder()
+                .eventMetaDAO(mockDao)
+                .pnPaperChannelConfig(mockConfig)
+                .build();
     }
 
     @Test


### PR DESCRIPTION
## Obiettivo
L'obiettivo di questo sviluppo è quello di permettere a paper channel di poter salvare informazioni riguardo il refinement analogico della notifica, all'interno dell'entità `PnDeliveryRequest`.

## Soluzione
Si è delegato all'handler `SendToDeliveryPushHandler` la responsabilità di salvare l'informazione se e solo se l'evento che deve inviare contiene uno stato di feedback, che in paper channel corrisponde al valore `StatusCodeEnum.OK`.
In questo modo, la logica è centralizzata in unico punto e non sparsa per i vari handler di gestione.

Inoltre, si è apportato un refactoring di tutti gli handler per poter garantire una migliore leggibilità e possibilità di aggiunta di nuovi parametri senza incorrere in code smells relativi a grosse quantità di parametri nel costruttore.
Nello specifico, si sono utilizzati i pattern `builder` e `parameter object` per ovviare questo problema.

Infine, sono stati implementati tutti i casi di test necessari.