### PR TITLE
Feature/PN-10517

### DIFF
--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnAddress.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnAddress.java
@@ -14,6 +14,8 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortK
 @ToString
 public class PnAddress {
 
+    public static final String ADDRESS_DYNAMO_TABLE_NAME = "AddressDynamoTable";
+
     private static final String COL_REQUEST_ID = "requestId";
 
     private static final String COL_FULL_NAME = "fullName";

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnDeliveryRequest.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnDeliveryRequest.java
@@ -73,6 +73,10 @@ public class PnDeliveryRequest {
 
     public static final String COL_REFINED = "refined";
 
+    public static final String COL_DRIVER_CODE = "driverCode";
+
+    public static final String COL_TENDER_CODE = "tenderCode";
+
     @Getter(onMethod = @__({@DynamoDbPartitionKey,@DynamoDbAttribute(COL_REQUEST_ID)}))
     private String requestId;
 
@@ -145,4 +149,10 @@ public class PnDeliveryRequest {
 
     @Getter(onMethod = @__({@DynamoDbAttribute(COL_REFINED)}))
     private Boolean refined;
+
+    @Getter(onMethod = @__({@DynamoDbAttribute(COL_DRIVER_CODE)}))
+    private String driverCode;
+
+    @Getter(onMethod = @__({@DynamoDbAttribute(COL_TENDER_CODE)}))
+    private String tenderCode;
 }

--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnDeliveryRequest.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/db/entities/PnDeliveryRequest.java
@@ -18,6 +18,8 @@ import java.util.List;
 @NoArgsConstructor
 public class PnDeliveryRequest {
 
+    public static final String REQUEST_DELIVERY_DYNAMO_TABLE_NAME = "RequestDeliveryDynamoTable";
+
     public static final String COL_REQUEST_ID = "requestId";
 
     @ToString.Exclude

--- a/src/main/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/service/impl/F24ServiceImpl.java
@@ -342,8 +342,8 @@ public class F24ServiceImpl extends GenericService implements F24Service {
                         receiverAddress,
                         ProductTypeEnum.fromValue(deliveryRequest.getProductType()),
                         StringUtils.equals(deliveryRequest.getPrintType(), Const.BN_FRONTE_RETRO)))
-                .map(analogCost -> {
-                    pnAttachmentInfo.setAnalogCost(Utility.toCentsFormat(analogCost));
+                .map(costWithDriver -> {
+                    pnAttachmentInfo.setAnalogCost(Utility.toCentsFormat(costWithDriver.getCost()));
                     return pnAttachmentInfo;
                 })
                 .doOnNext(analogCost -> logAuditSuccessLogic("preparePDF requestId = %s, relatedRequestId = %s Receiver address is present on DB, computed cost " + analogCost, deliveryRequest, pnLogAudit));

--- a/src/main/java/it/pagopa/pn/paperchannel/service/impl/PaperMessagesServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/service/impl/PaperMessagesServiceImpl.java
@@ -316,10 +316,10 @@ public class  PaperMessagesServiceImpl extends BaseService implements PaperMessa
 
     private Mono<SendResponse> getSendResponse(Address address, List<AttachmentInfo> attachments, ProductTypeEnum productType, boolean isReversePrinter){
         return this.paperCalculatorUtils.calculator(attachments, address, productType, isReversePrinter)
-                .map(amount -> {
+                .map(costWithDriver -> {
                     int totalPages = this.paperCalculatorUtils.getNumberOfPages(attachments, isReversePrinter, true);
-                    Integer amountPriceFormat = Utility.toCentsFormat(amount);
-                    log.debug("Amount : {}", amount);
+                    Integer amountPriceFormat = Utility.toCentsFormat(costWithDriver.getCost());
+                    log.debug("Amount : {}", costWithDriver.getCost());
                     log.debug("Total pages : {}", totalPages);
                     SendResponse response = new SendResponse();
                     response.setAmount(amountPriceFormat);

--- a/src/main/java/it/pagopa/pn/paperchannel/service/impl/PaperMessagesServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/service/impl/PaperMessagesServiceImpl.java
@@ -390,7 +390,11 @@ public class  PaperMessagesServiceImpl extends BaseService implements PaperMessa
     private Mono<PnDeliveryRequest> saveRequestAndAddress(PrepareRequest prepareRequest, boolean reworkNeeded, Integer reworkNeededCount){
         String processName = "Save Request and Address";
         log.logStartingProcess(processName);
+
         PnDeliveryRequest pnDeliveryRequest = RequestDeliveryMapper.toEntity(prepareRequest);
+        // Init refined field as false
+        pnDeliveryRequest.setRefined(false);
+
         PnAddress receiverAddressEntity = null;
         PnAddress discoveredAddressEntity = null;
 

--- a/src/main/java/it/pagopa/pn/paperchannel/utils/costutils/CostWithDriver.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/utils/costutils/CostWithDriver.java
@@ -1,0 +1,17 @@
+package it.pagopa.pn.paperchannel.utils.costutils;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+public class CostWithDriver {
+
+    private BigDecimal cost;
+    private String driverCode;
+    private String tenderCode;
+}

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/RequestDeliveryDAOTestIT.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/RequestDeliveryDAOTestIT.java
@@ -35,7 +35,9 @@ class RequestDeliveryDAOTestIT extends BaseTest {
         Mockito.when(dataVaultEncryption.encode(Mockito.any(), Mockito.any())).thenReturn("returnOk");
         Mockito.when(dataVaultEncryption.decode(Mockito.any())).thenReturn("returnOk");
         PnDeliveryRequest createRequest = this.requestDeliveryDAO.createWithAddress(request, address, null).block();
+
         assertNotNull(createRequest);
+        assertEquals(createRequest, request);
     }
 
     @Test
@@ -43,36 +45,48 @@ class RequestDeliveryDAOTestIT extends BaseTest {
         Mockito.when(dataVaultEncryption.encode(Mockito.any(), Mockito.any())).thenReturn("returnOk");
         Mockito.when(dataVaultEncryption.decode(Mockito.any())).thenReturn("returnOk");
         PnDeliveryRequest createRequest2 = this.requestDeliveryDAO.createWithAddress(request1, null, null).block();
+
         assertNotNull(createRequest2);
+        assertEquals(createRequest2, request1);
     }
+
     @Test
     void updateDataTest(){
         Mockito.when(dataVaultEncryption.encode(Mockito.any(), Mockito.any())).thenReturn("returnOk");
         Mockito.when(dataVaultEncryption.decode(Mockito.any())).thenReturn("returnOk");
         PnDeliveryRequest createRequest = this.requestDeliveryDAO.createWithAddress(request2, address, null).block();
         PnDeliveryRequest updateRequest = this.requestDeliveryDAO.updateData(duplicateRequest).block();
+
         assertNotNull(updateRequest);
+        assertEquals(createRequest, request2);
+        assertEquals(updateRequest, duplicateRequest);
     }
+
     @Test
     void getByRequestIdTest(){
         PnDeliveryRequest deliveryRequest = this.requestDeliveryDAO.getByRequestId(request.getRequestId()).block();
         assertNotNull(deliveryRequest);
     }
+
     @Test
     void getByRequestIdNotPresentTest(){
         String requestId = "id-123456";
         PnDeliveryRequest deliveryRequest = this.requestDeliveryDAO.getByRequestId(requestId).block();
+
         assertNull(deliveryRequest);
     }
+
     @Test
     void getByCorrelationIdTest(){
         PnDeliveryRequest deliveryRequest = this.requestDeliveryDAO.getByCorrelationId(duplicateRequest.getCorrelationId()).block();
         assertNotNull(deliveryRequest);
     }
+
     @Test
     void getByCorrelationIdNotPresentTest(){
         String correlationId = "idCor";
         PnDeliveryRequest deliveryRequest = this.requestDeliveryDAO.getByCorrelationId(correlationId).block();
+
         assertNull(deliveryRequest);
     }
 
@@ -85,12 +99,14 @@ class RequestDeliveryDAOTestIT extends BaseTest {
         request.setProductType("type");
         request.setFiscalCode("FRMTTR76M06B715E");
         request.setReceiverType("PF");
+        request.setRefined(false);
 
         request1.setRequestId("id-1212");
         request1.setProductType("reqeeww");
         request1.setCorrelationId("idcor-78867");
         request1.setReceiverType("PF");
         request1.setFiscalCode("FRMTTR76M06B715E");
+        request1.setRefined(false);
 
         request2.setRequestId("id-54321");
         request2.setProductType("req");
@@ -99,6 +115,7 @@ class RequestDeliveryDAOTestIT extends BaseTest {
         request2.setProductType("type");
         request2.setFiscalCode("FRMTTR76M06B715E");
         request2.setReceiverType("PF");
+        request2.setRefined(false);
 
         duplicateRequest.setRequestId("id-54321");
         duplicateRequest.setProductType("req");
@@ -107,6 +124,7 @@ class RequestDeliveryDAOTestIT extends BaseTest {
         duplicateRequest.setProductType("type");
         duplicateRequest.setFiscalCode("FRMTTR76M06B715E");
         duplicateRequest.setReceiverType("PF");
+        duplicateRequest.setRefined(false);
 
         address.setAddress("Via Aldo Moro");
         address.setCap("21004");

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/RequestDeliveryDAOTestIT.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/db/dao/RequestDeliveryDAOTestIT.java
@@ -125,6 +125,8 @@ class RequestDeliveryDAOTestIT extends BaseTest {
         duplicateRequest.setFiscalCode("FRMTTR76M06B715E");
         duplicateRequest.setReceiverType("PF");
         duplicateRequest.setRefined(false);
+        duplicateRequest.setDriverCode("driverCode");
+        duplicateRequest.setTenderCode("tenderCode");
 
         address.setAddress("Via Aldo Moro");
         address.setCap("21004");

--- a/src/test/java/it/pagopa/pn/paperchannel/utils/PaperCalculatorUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/utils/PaperCalculatorUtilsTest.java
@@ -6,6 +6,7 @@ import it.pagopa.pn.paperchannel.generated.openapi.server.v1.dto.ProductTypeEnum
 import it.pagopa.pn.paperchannel.model.Address;
 import it.pagopa.pn.paperchannel.model.AttachmentInfo;
 import it.pagopa.pn.paperchannel.service.PaperTenderService;
+import it.pagopa.pn.paperchannel.utils.costutils.CostWithDriver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,10 +55,10 @@ class PaperCalculatorUtilsTest {
         Address address = new Address();
         address.setCap("30030");
 
-        BigDecimal res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
+        CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
-        Assertions.assertEquals(1, res.intValue());
+        Assertions.assertEquals(1, res.getCost().intValue());
     }
 
     //${peso busta} + ( ${numero di pagine} * ${peso pagina} )
@@ -88,10 +89,10 @@ class PaperCalculatorUtilsTest {
         Mockito.when(pnPaperChannelConfig.getPaperWeight()).thenReturn(5);
         Mockito.when(pnPaperChannelConfig.getLetterWeight()).thenReturn(5);
 
-        BigDecimal res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
+        CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
-        Assertions.assertEquals(1, res.intValue());
+        Assertions.assertEquals(1, res.getCost().intValue());
     }
 
     //${peso busta} + ( ${numero di pagine} * ${peso pagina} )
@@ -130,10 +131,10 @@ class PaperCalculatorUtilsTest {
         Mockito.when(pnPaperChannelConfig.getPaperWeight()).thenReturn(5);
         Mockito.when(pnPaperChannelConfig.getLetterWeight()).thenReturn(5);
 
-        BigDecimal res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
+        CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
-        Assertions.assertEquals(12, res.intValue());
+        Assertions.assertEquals(12, res.getCost().intValue());
     }
 
 
@@ -173,10 +174,10 @@ class PaperCalculatorUtilsTest {
         Mockito.when(pnPaperChannelConfig.getPaperWeight()).thenReturn(5);
         Mockito.when(pnPaperChannelConfig.getLetterWeight()).thenReturn(5);
 
-        BigDecimal res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
+        CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
-        Assertions.assertEquals(18, res.intValue());
+        Assertions.assertEquals(18, res.getCost().intValue());
     }
 
     //${peso busta} + ( ${numero di pagine} * ${peso pagina} )
@@ -215,10 +216,10 @@ class PaperCalculatorUtilsTest {
         Mockito.when(pnPaperChannelConfig.getPaperWeight()).thenReturn(5);
         Mockito.when(pnPaperChannelConfig.getLetterWeight()).thenReturn(5);
 
-        BigDecimal res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
+        CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
-        Assertions.assertEquals(21, res.intValue());
+        Assertions.assertEquals(21, res.getCost().intValue());
     }
 
     @Test
@@ -245,10 +246,10 @@ class PaperCalculatorUtilsTest {
         Address address = new Address();
         address.setCountry("FRANCE");
 
-        BigDecimal res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
+        CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
-        Assertions.assertEquals(223,  (int)(res.floatValue()*100));
+        Assertions.assertEquals(223,  (int)(res.getCost().floatValue()*100));
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/paperchannel/utils/PaperCalculatorUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/utils/PaperCalculatorUtilsTest.java
@@ -7,6 +7,7 @@ import it.pagopa.pn.paperchannel.model.Address;
 import it.pagopa.pn.paperchannel.model.AttachmentInfo;
 import it.pagopa.pn.paperchannel.service.PaperTenderService;
 import it.pagopa.pn.paperchannel.utils.costutils.CostWithDriver;
+import org.apache.poi.ss.formula.functions.T;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 class PaperCalculatorUtilsTest {
+
+    private static final String DRIVER_CODE = "driverCode";
+    private static final String TENDER_CODE = "tenderCode";
 
     @InjectMocks
     private PaperCalculatorUtils paperCalculatorUtils;
@@ -58,7 +62,10 @@ class PaperCalculatorUtilsTest {
         CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
+
         Assertions.assertEquals(1, res.getCost().intValue());
+        Assertions.assertEquals(DRIVER_CODE, res.getDriverCode());
+        Assertions.assertEquals(TENDER_CODE, res.getTenderCode());
     }
 
     //${peso busta} + ( ${numero di pagine} * ${peso pagina} )
@@ -92,7 +99,10 @@ class PaperCalculatorUtilsTest {
         CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
+
         Assertions.assertEquals(1, res.getCost().intValue());
+        Assertions.assertEquals(DRIVER_CODE, res.getDriverCode());
+        Assertions.assertEquals(TENDER_CODE, res.getTenderCode());
     }
 
     //${peso busta} + ( ${numero di pagine} * ${peso pagina} )
@@ -134,7 +144,10 @@ class PaperCalculatorUtilsTest {
         CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
+
         Assertions.assertEquals(12, res.getCost().intValue());
+        Assertions.assertEquals(DRIVER_CODE, res.getDriverCode());
+        Assertions.assertEquals(TENDER_CODE, res.getTenderCode());
     }
 
 
@@ -177,7 +190,10 @@ class PaperCalculatorUtilsTest {
         CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
+
         Assertions.assertEquals(18, res.getCost().intValue());
+        Assertions.assertEquals(DRIVER_CODE, res.getDriverCode());
+        Assertions.assertEquals(TENDER_CODE, res.getTenderCode());
     }
 
     //${peso busta} + ( ${numero di pagine} * ${peso pagina} )
@@ -219,7 +235,10 @@ class PaperCalculatorUtilsTest {
         CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
+
         Assertions.assertEquals(21, res.getCost().intValue());
+        Assertions.assertEquals(DRIVER_CODE, res.getDriverCode());
+        Assertions.assertEquals(TENDER_CODE, res.getTenderCode());
     }
 
     @Test
@@ -249,7 +268,10 @@ class PaperCalculatorUtilsTest {
         CostWithDriver res = paperCalculatorUtils.calculator(attachmentUrls, address, ProductTypeEnum.AR, true).block();
 
         assert res != null;
+
         Assertions.assertEquals(223,  (int)(res.getCost().floatValue()*100));
+        Assertions.assertEquals(DRIVER_CODE, res.getDriverCode());
+        Assertions.assertEquals(TENDER_CODE, res.getTenderCode());
     }
 
     @Test
@@ -400,6 +422,8 @@ class PaperCalculatorUtilsTest {
         dto.setPrice1000(BigDecimal.valueOf(6.00));
         dto.setPrice2000(BigDecimal.valueOf(7.00));
         dto.setPriceAdditional(BigDecimal.valueOf(2.00));
+        dto.setDriverCode(DRIVER_CODE);
+        dto.setTenderCode(TENDER_CODE);
         return dto;
     }
 
@@ -407,6 +431,8 @@ class PaperCalculatorUtilsTest {
         CostDTO dto = new CostDTO();
         dto.setPrice(BigDecimal.valueOf(2.23));
         dto.setPriceAdditional(BigDecimal.valueOf(1.97));
+        dto.setDriverCode(DRIVER_CODE);
+        dto.setTenderCode(TENDER_CODE);
         return dto;
     }
 }


### PR DESCRIPTION
## Obiettivo
L'obiettivo di questo task è quello di portare le informazioni del recapitista all'interno della tabella PnDeliveryRequest, salvando le informazioni: `driverCode` e `tenderCode`.

## Soluzione
Si è sfruttato il calcolo del costo effettuato in fase di SEND per poter recuperare anche le informazioni del recapitista, visto che sono comunque necessarie al calcolo del costo della spedizione cartacea.
Nello specifico, il metodo `PaperCalculatorUtils#calculator` ritorna ora un oggetto `CostWithDriver` che funge da wrapper per il costo e per le informazioni del recapitista:

```
public class CostWithDriver {
    private BigDecimal cost;
    private String driverCode;
    private String tenderCode;
}
```

Infine, sono stati risolti alcuni code smells con priorità alta, segnalati da Sonar nelle classi Java oggetto della modifica.