### PR TITLE
refactor(PN-10902): remove duplicate handler entries

### DIFF
--- a/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactory.java
@@ -432,9 +432,6 @@ public class HandlersFactory {
         map.put(ExternalChannelCodeEnum.RECRS005C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRN001C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECRN002F.name(), handler);
-        map.put(ExternalChannelCodeEnum.RECRN003C.name(), handler);
-        map.put(ExternalChannelCodeEnum.RECRN004C.name(), handler);
-        map.put(ExternalChannelCodeEnum.RECRN005C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECAG001C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECAG002C.name(), handler);
         map.put(ExternalChannelCodeEnum.RECAG003F.name(), handler);

--- a/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactoryTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/middleware/queue/consumer/handler/HandlersFactoryTest.java
@@ -77,7 +77,8 @@ class HandlersFactoryTest {
                         new TestCase("NotRetryable", List.of("CON998"), NotRetryableErrorMessageHandler.class),
                         new TestCase("Log", List.of("UNKNOWN"), LogMessageHandler.class),
                         new TestCase("Complex890", List.of("RECAG005C", "RECAG006C", "RECAG007C", "RECAG008C"),
-                                Proxy890MessageHandler.class)
+                                Proxy890MessageHandler.class),
+                        new TestCase("RECRN00xC", List.of("RECRN003C", "RECRN004C", "RECRN005C"), RECRN00XCMessageHandler.class)
                     )),
             // SIMPLE_890_FLOW ENABLE cases
             new FFTestCases(


### PR DESCRIPTION
- Remove duplicate handlers for RECRN003C, RECRN004C, RECRN005C from HandlersFactory.
- Add a test case for RECRN00xC in HandlersFactoryTest.