### PR TITLE
[PN-17856] - Added attempt and recIndex attribute to prepare and send API

### DIFF
--- a/docs/openapi/schemas-paper-v1.yaml
+++ b/docs/openapi/schemas-paper-v1.yaml
@@ -38,6 +38,8 @@ components:
       - requestPaId
       - senderAddress
       - iun
+      - recIndex
+      - attempt
       type: object
       properties:
         requestPaId:
@@ -56,6 +58,12 @@ components:
           $ref: '#/components/schemas/AnalogAddress'
         productType:
           $ref: '#/components/schemas/ProductTypeEnum'
+        recIndex:
+          type: integer
+          description: Indice del destinatario
+        attempt:
+          type: integer
+          description: Indice di tentativo di invio (0 per il primo invio, 1 per il secondo, ecc.)
       allOf:
       - $ref: '#/components/schemas/PaperRequest'
     SendResponse:
@@ -233,6 +241,8 @@ components:
       - receiverFiscalCode
       - receiverType
       - iun
+      - recIndex
+      - attempt
       type: object
       properties:
         relatedRequestId:
@@ -250,6 +260,12 @@ components:
         aarWithRadd:
           type: boolean
           description: Se true, indica che la notifica fa parte della sperimentazione RADD
+        recIndex:
+          type: integer
+          description: Indice del destinatario del recapito
+        attempt:
+          type: integer
+          description: Indice di tentativo di invio (0 per il primo invio, 1 per il secondo, ecc.)
       allOf:
       - $ref: '#/components/schemas/PaperRequest'
     Problem:

--- a/src/test/java/it/pagopa/pn/paperchannel/config/InstanceCreator.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/config/InstanceCreator.java
@@ -133,6 +133,8 @@ public class InstanceCreator {
         prepareRequest.setProposalProductType(ProposalTypeEnum.AR);
         prepareRequest.setReceiverFiscalCode("FRMTTR76M06B715E");
         prepareRequest.setReceiverType("PF");
+        prepareRequest.setAttempt(0);
+        prepareRequest.setRecIndex(0);
         return prepareRequest;
     }
 

--- a/src/test/java/it/pagopa/pn/paperchannel/rest/v1/PaperMessagesRestV1ControllerTest.java
+++ b/src/test/java/it/pagopa/pn/paperchannel/rest/v1/PaperMessagesRestV1ControllerTest.java
@@ -110,6 +110,8 @@ class PaperMessagesRestV1ControllerTest{
         sendRequest.setReceiverAddress(analogAddress);
         sendRequest.setPrintType("pr");
         sendRequest.setAttachmentUrls(attachmentUrls);
+        sendRequest.setAttempt(0);
+        sendRequest.setRecIndex(0);
         return sendRequest;
     }
 
@@ -141,6 +143,8 @@ class PaperMessagesRestV1ControllerTest{
         prepareRequest.setReceiverFiscalCode("FRMTTR76M06B715E");
         prepareRequest.setReceiverType("PF");
         prepareRequest.setAarWithRadd(true);
+        prepareRequest.setAttempt(0);
+        prepareRequest.setRecIndex(0);
         return prepareRequest;
     }
 }


### PR DESCRIPTION
[PN-17856] - Added attempt and recIndex attribute to prepare and send API

[PN-17856]: https://pagopa.atlassian.net/browse/PN-17856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ